### PR TITLE
Align C++ implementation with decompiled ground truth behavior

### DIFF
--- a/inc/Info/cltClientPetKindInfo.h
+++ b/inc/Info/cltClientPetKindInfo.h
@@ -12,6 +12,8 @@
 //
 // 此 C++ 還原採用組合（composition），與反編譯行為等價：
 // cltPetKindInfo 為成員，在建構子被初始化；動畫表亦為固定陣列成員。
+// 注意：ground truth 的建構子不會初始化動畫表，依賴全域物件之 BSS
+// 零值初始化（g_clPetKindInfo）。此處同樣不提供預設初始化以忠實對齊。
 class cltClientPetKindInfo {
 public:
     cltClientPetKindInfo();
@@ -34,5 +36,5 @@ public:
 
 private:
     cltPetKindInfo  m_petKindInfo;                 // +0x04 (after vftable)
-    cltPetAniInfo*  m_aniInfoTable[0xFFFF] = {};   // +0x14
+    cltPetAniInfo*  m_aniInfoTable[0xFFFF];        // +0x14 (zero-init via BSS)
 };

--- a/inc/Info/cltClientPortalInfo.h
+++ b/inc/Info/cltClientPortalInfo.h
@@ -18,7 +18,8 @@ class Map;
 class cltClientPortalInfo {
 public:
     cltClientPortalInfo();
-    ~cltClientPortalInfo();
+    // 注意：ground truth 沒有使用者定義的解構子 (dtor 主體未出現在 mofclient.c)，
+    // 由 compiler 產生 trivial dtor。本還原遵循該行為，不提供顯式 dtor。
 
     // 靜態初始化：儲存 cltPortalInfo/Map 指標
     static void InitializeStaticVariable(cltPortalInfo* portalInfo, Map* map);

--- a/src/Info/cltClientCharKindInfo.cpp
+++ b/src/Info/cltClientCharKindInfo.cpp
@@ -64,13 +64,11 @@ void cltClientCharKindInfo::Free()
     //       operator delete(v4);
     //       *v3 = 0;
     //   cltCharKindInfo::Free(this);
-    if (m_ppMonsterAniInfoTable) {
-        for (int i = 0; i < 0xFFFF; ++i) {
-            cltMonsterAniInfo* entry = m_ppMonsterAniInfoTable[i];
-            if (entry) {
-                delete entry;                    // dtor + operator delete
-                m_ppMonsterAniInfoTable[i] = nullptr;
-            }
+    for (int i = 0; i < 0xFFFF; ++i) {
+        cltMonsterAniInfo* entry = m_ppMonsterAniInfoTable[i];
+        if (entry) {
+            delete entry;                    // dtor + operator delete
+            m_ppMonsterAniInfoTable[i] = nullptr;
         }
     }
     cltCharKindInfo::Free();
@@ -100,7 +98,7 @@ cltMonsterAniInfo* cltClientCharKindInfo::GetMonsterAniInfo(unsigned short a2)
     //       }
     //   }
     //   return result;
-    if (m_ppMonsterAniInfoTable && m_ppMonsterAniInfoTable[a2])
+    if (m_ppMonsterAniInfoTable[a2])
         return m_ppMonsterAniInfoTable[a2];
 
     void* rawResult = cltCharKindInfo::GetCharKindInfo(a2);
@@ -113,8 +111,7 @@ cltMonsterAniInfo* cltClientCharKindInfo::GetMonsterAniInfo(unsigned short a2)
         return nullptr;
 
     cltMonsterAniInfo* ani = new cltMonsterAniInfo();
-    if (m_ppMonsterAniInfoTable)
-        m_ppMonsterAniInfoTable[a2] = ani;
+    m_ppMonsterAniInfoTable[a2] = ani;
 
     if (!ani->Initialize(aniFileName)) {
         CHAR Text[1024];
@@ -123,7 +120,7 @@ cltMonsterAniInfo* cltClientCharKindInfo::GetMonsterAniInfo(unsigned short a2)
         return nullptr;
     }
 
-    return m_ppMonsterAniInfoTable ? m_ppMonsterAniInfoTable[a2] : ani;
+    return m_ppMonsterAniInfoTable[a2];
 }
 
 // (0x00401590)

--- a/src/Info/cltClientPetKindInfo.cpp
+++ b/src/Info/cltClientPetKindInfo.cpp
@@ -16,8 +16,9 @@ cltClientPetKindInfo::cltClientPetKindInfo()
     //   cltPetKindInfo::cltPetKindInfo((char *)this + 4);
     //   *(_DWORD *)this = &cltClientPetKindInfo::vftable;
     //   return this;
-    // (組合成員 m_petKindInfo 會被編譯器預先建構)
-    std::memset(m_aniInfoTable, 0, sizeof(m_aniInfoTable));
+    // ground truth 未對 m_aniInfoTable 做任何初始化；g_clPetKindInfo 為
+    // 全域物件，依賴 BSS 零值初始化。(組合成員 m_petKindInfo 會被編譯器
+    // 預先建構)
 }
 
 // (0x004EDA60)

--- a/src/Info/cltClientPortalInfo.cpp
+++ b/src/Info/cltClientPortalInfo.cpp
@@ -16,23 +16,15 @@ Map*           cltClientPortalInfo::m_pMap          = nullptr;
 
 // (0x004E1350)
 cltClientPortalInfo::cltClientPortalInfo()
-    : m_pPortalBuffer(nullptr)
-    , m_nPortalCount(0)
-    , m_wMapKind(0)
-    , _pad32(0)
 {
-    // mofclient.c constructor 只 return this，未初始化成員；在 C++ 端
-    // 為避免使用到未初始化記憶體，這裡提供零值預設。行為等價於原始 binary
-    // 在呼叫 Init / Free 之前欄位未被使用的情境。
-    std::memset(m_nIndexBuffer, 0, sizeof(m_nIndexBuffer));
+    // mofclient.c constructor 只 return this，未初始化任何成員。
+    //   cltClientPortalInfo *__thiscall cltClientPortalInfo::cltClientPortalInfo(cltClientPortalInfo *this)
+    //   { return this; }
+    // g_clClientPortalInfo 為全域物件，依賴 BSS 零值初始化。忠實對齊
+    // 反編譯：此處同樣不做任何欄位賦值。
 }
 
-cltClientPortalInfo::~cltClientPortalInfo()
-{
-    // 原始 binary 沒有明確的 dtor；退出時由 OS 釋放。
-    // 這裡主動呼叫 Free 以符合 RAII。
-    Free();
-}
+// Ground truth 沒有使用者定義的 destructor —— 由 compiler 產生 trivial dtor。
 
 // (0x004E1370)
 void cltClientPortalInfo::InitializeStaticVariable(cltPortalInfo* a1, Map* a2)
@@ -61,41 +53,45 @@ void cltClientPortalInfo::GetPortalInfo(uint16_t a2, int* a3)
     //   v4 = cltPortalInfo::GetPortalCntInMap(m_pclPortalInfo, a2, a3);
     //   *((_DWORD *)this + 11) = v4;            // m_nPortalCount
     //   v5 = operator new(40 * v4);
-    //   v6 = m_nPortalCount;
-    //   *(_DWORD *)this = v5;                   // m_pPortalBuffer
+    //   v6 = *((_DWORD *)this + 11);
+    //   *(_DWORD *)this = v5;                   // m_pPortalBuffer (直接覆寫)
     //   v9 = 0;
     //   if ( v6 > 0 ) {
     //       v10 = 0;
-    //       v7 = (int *)((char *)this + 4);     // 讀取剛寫入的 index 陣列
+    //       v7 = (int *)((char *)this + 4);     // 固定讀取 this+4 的 index 陣列
     //       do {
     //           v8 = cltPortalInfo::GetPortalInfoByIndex(m_pclPortalInfo, *v7++);
     //           qmemcpy((char *)v10 + *(_DWORD *)this, v8, 0x28u);  // 40 bytes
     //           ++v9;
     //           v10 += 10;  // 10 * 4 = 40 bytes
-    //       } while ( v9 < m_nPortalCount );
+    //       } while ( v9 < *((_DWORD *)this + 11) );
     //   }
-    if (!m_pclPortalInfo)
-        return;
-
-    int count = m_pclPortalInfo->GetPortalCntInMap(a2, a3);
+    //
+    // 忠實對齊反編譯行為：
+    //   * 不檢查 m_pclPortalInfo
+    //   * 不釋放舊的 m_pPortalBuffer（原始 binary 直接覆寫造成 leak，
+    //     呼叫端需先呼叫 Free）
+    //   * 即使 count == 0 仍呼叫 operator new
+    //   * 迴圈內固定讀取 (int*)this + 1 (m_nIndexBuffer)，忽略參數 a3
+    int count = cltClientPortalInfo::m_pclPortalInfo->GetPortalCntInMap(a2, a3);
     m_nPortalCount = count;
 
-    if (m_pPortalBuffer) {
-        // 避免覆蓋舊 buffer 造成洩漏 (原始 binary 預期呼叫端事先 Free，
-        // 我們補上以維持正確性)
-        ::operator delete(m_pPortalBuffer);
-        m_pPortalBuffer = nullptr;
-    }
+    m_pPortalBuffer = static_cast<stPortalInfo*>(
+        ::operator new(sizeof(stPortalInfo) * static_cast<std::size_t>(count)));
 
     if (count > 0) {
-        m_pPortalBuffer = static_cast<stPortalInfo*>(
-            ::operator new(sizeof(stPortalInfo) * static_cast<std::size_t>(count)));
-        for (int i = 0; i < count; ++i) {
-            stPortalInfo* src = m_pclPortalInfo->GetPortalInfoByIndex(a3[i]);
-            std::memcpy(reinterpret_cast<char*>(m_pPortalBuffer) + i * sizeof(stPortalInfo),
-                        src,
+        int* v7 = m_nIndexBuffer;  // 對齊 ground truth: (int *)((char *)this + 4)
+        int v9 = 0;
+        int v10 = 0;
+        do {
+            stPortalInfo* v8 =
+                cltClientPortalInfo::m_pclPortalInfo->GetPortalInfoByIndex(*v7++);
+            std::memcpy(reinterpret_cast<char*>(m_pPortalBuffer) + v10,
+                        v8,
                         0x28u);
-        }
+            ++v9;
+            v10 += 40;  // v10 += 10 (int*) == +40 bytes
+        } while (v9 < m_nPortalCount);
     }
 }
 
@@ -103,8 +99,8 @@ void cltClientPortalInfo::GetPortalInfo(uint16_t a2, int* a3)
 stPortalInfo* cltClientPortalInfo::GetPortalInfoByPortalID(uint16_t a2)
 {
     // mofclient.c: return cltPortalInfo::GetPortalInfoByID(m_pclPortalInfo, a2);
-    if (!m_pclPortalInfo) return nullptr;
-    return m_pclPortalInfo->GetPortalInfoByID(a2);
+    // 忠實對齊 ground truth：不做 m_pclPortalInfo null-check。
+    return cltClientPortalInfo::m_pclPortalInfo->GetPortalInfoByID(a2);
 }
 
 // (0x004E1460)
@@ -173,7 +169,7 @@ unsigned char cltClientPortalInfo::IsPortalAction(int pt, int pt_4,
         return 1;
 
     int v10 = a8;
-    RECT rc{};
+    RECT rc;  // ground truth 未初始化 rc（UB 但忠實對齊）
 
     for (int i = 0; ; i += 40) {
         char* v12 = reinterpret_cast<char*>(m_pPortalBuffer) + i;


### PR DESCRIPTION
## Summary
This PR refactors the C++ implementation of several client info classes to more faithfully match the decompiled ground truth from the original binary, removing defensive programming practices that diverged from the original behavior.

## Key Changes

### cltClientPortalInfo
- **Constructor**: Removed member initialization (memset) to match original binary behavior where the constructor only returns `this` without initialization. Relies on BSS zero-initialization for the global object `g_clClientPortalInfo`.
- **Destructor**: Removed user-defined destructor and the explicit `Free()` call. The ground truth has no user-defined destructor; the compiler generates a trivial one.
- **GetPortalInfo()**: 
  - Removed null-check for `m_pclPortalInfo` to match decompiled behavior
  - Removed defensive deallocation of old `m_pPortalBuffer` (original binary directly overwrites, causing a leak; callers are expected to call `Free()` first)
  - Removed conditional allocation; `operator new` is called even when `count == 0`
  - Refactored loop to use fixed array indexing `m_nIndexBuffer` instead of parameter `a3`, matching the decompiled assembly
- **GetPortalInfoByPortalID()**: Removed null-check for `m_pclPortalInfo`
- **IsPortalAction()**: Changed `RECT rc{}` to `RECT rc` (uninitialized) to match ground truth behavior

### cltClientCharKindInfo
- **Free()**: Removed outer null-check for `m_ppMonsterAniInfoTable` before iterating; the loop now executes unconditionally
- **GetMonsterAniInfo()**: 
  - Removed redundant null-check for `m_ppMonsterAniInfoTable` in the initial condition
  - Removed null-check before assignment to `m_ppMonsterAniInfoTable[a2]`
  - Simplified return statement to directly return `m_ppMonsterAniInfoTable[a2]` instead of conditional ternary

### cltClientPetKindInfo
- **Constructor**: Removed `memset` initialization of `m_aniInfoTable`. The global object relies on BSS zero-initialization.
- **Header**: Updated `m_aniInfoTable` member from `= {}` to uninitialized declaration with a comment explaining BSS zero-initialization dependency

## Implementation Details
- All changes prioritize fidelity to the decompiled ground truth over defensive programming
- Comments added throughout to explain the rationale for seemingly unsafe patterns (e.g., missing null-checks, uninitialized variables)
- Global objects (`g_clClientPortalInfo`, `g_clPetKindInfo`) depend on BSS segment zero-initialization rather than constructor initialization
- The refactoring maintains behavioral equivalence with the original binary while removing safety checks that were not present in the decompilation

https://claude.ai/code/session_015pHxB36MQmaqkRvBcVW5yX