### PR TITLE
Refactor cltPKManager to align with GT implementation

### DIFF
--- a/inc/Logic/cltPKManager.h
+++ b/inc/Logic/cltPKManager.h
@@ -136,18 +136,23 @@ public:
     // 費用
     int  GetCost(int level, int team);
 
-    // 公開成員 — 提供給外部直接存取 (對齊 GT 用法)
+private:
+    // ---- 以下成員順序對齊 GT (mofclient.c:198787 cltPKManager 建構子) ----
+    // GT 佈局：vftable@+0、5 個 map@+4..+83、m_iter@+84、m_currentRoom@+88、
+    //          players@+656、m_extraData@+7232、m_gameLevelSetting@+7280...
+
+    // offset +4: 5 個 map，依 gameLevel 分類 (0~4)
+    std::map<unsigned long, stPKRoomInfo*> m_mapRooms[5];
+
+    // offset +84: 迭代器狀態 (跨方法共用)
+    std::map<unsigned long, stPKRoomInfo*>::iterator m_iter;
+
+public:
+    // offset +88: 公開成員 — 提供給外部直接存取 (對齊 GT 用法)
     stPKRoomInfo m_currentRoom;
 
 private:
-    // 5 個 map，依 gameLevel 分類 (0~4)
-    std::map<unsigned long, stPKRoomInfo*> m_mapRooms[5];
-
-    // 迭代器狀態 (跨方法共用)
-    std::map<unsigned long, stPKRoomInfo*>::iterator m_iter;
-    int m_iterMapIdx;
-
-    // offset 7232: 額外資料區
+    // offset +7232: 額外資料區
     char m_extraData[48];
 
     // offset 7280+

--- a/src/Logic/cltPKManager.cpp
+++ b/src/Logic/cltPKManager.cpp
@@ -174,7 +174,6 @@ cltPKManager::cltPKManager()
     std::memset(m_unkName1, 0, 256);
     std::memset(m_unkName2, 0, 256);
 
-    m_iterMapIdx = 0;
     m_iter = m_mapRooms[0].end();
 }
 
@@ -325,27 +324,24 @@ void cltPKManager::AddPKRoomInfoByLobby(stPKRoomInfo* pInfo)
 
 int cltPKManager::GetGameLevelByHandle(unsigned int handleID)
 {
+    // GT (mofclient.c:199444) 對每個 map 呼叫 find/lower_bound，
+    // 並將結果寫回 m_iter (offset +84) 即使 find 失敗也寫入。
     for (int i = 0; i < 5; i++)
     {
         auto it = m_mapRooms[i].find(handleID);
+        m_iter = it;
         if (it != m_mapRooms[i].end())
-        {
-            m_iter = it;
-            m_iterMapIdx = i;
             return i;
-        }
     }
     return -1;
 }
 
 void cltPKManager::SetPKRoomInfoCreate(stPKRoomInfo* pInfo)
 {
-    if (&m_currentRoom == (stPKRoomInfo*)((char*)this + 0) || (stPKRoomInfo*)pInfo == &m_currentRoom)
-    {
-        // self-assignment check: if pInfo points to m_currentRoom, skip
-        if (pInfo == &m_currentRoom)
-            return;
-    }
+    // GT (mofclient.c:199519) 只做單純的 self-assignment 檢查：
+    //   if ( (char*)this + 88 != a2 ) { ...copy... }
+    if (pInfo == &m_currentRoom)
+        return;
 
     m_currentRoom.handleID = pInfo->handleID;
     m_currentRoom.hostAccountID = pInfo->hostAccountID;
@@ -381,7 +377,6 @@ int cltPKManager::CopyPKRoomInfoFromList(int a2, int a3)
 
     // Get begin iterator and advance to position a3
     m_iter = m_mapRooms[a2].begin();
-    m_iterMapIdx = a2;
 
     for (int i = 0; i < a3; i++)
     {
@@ -477,6 +472,11 @@ void cltPKManager::DestroyRoom(unsigned int handleID)
 
 void cltPKManager::UpdatePKRoomInfo(stPKRoomInfo* pInfo)
 {
+    // GT (mofclient.c:200037) 流程：
+    //   m_currentRoom.gameLevel = m_gameLevelSetting;
+    //   依序在 map0..map4 呼叫 find/insert/operator[]，將結果寫回 m_iter；
+    //   找到 → 對既有 entry 呼叫 operator= 進行 in-place 更新。
+    //   全部都找不到 → 不做任何事 (GT 沒有「建立新房間」的 fallback)。
     if (!pInfo)
         return;
 
@@ -484,34 +484,19 @@ void cltPKManager::UpdatePKRoomInfo(stPKRoomInfo* pInfo)
 
     unsigned long handleID = pInfo->handleID;
 
-    // Search through all maps for the handleID
     for (int i = 0; i < 5; i++)
     {
         auto it = m_mapRooms[i].find(handleID);
+        m_iter = it;
         if (it != m_mapRooms[i].end())
         {
-            m_iter = it;
-            m_iterMapIdx = i;
-
-            // Found — update the room data
+            // Found — update the existing room (skip self-assignment)
             if (it->second != pInfo)
-            {
                 it->second->operator=((char*)pInfo);
-            }
             return;
         }
     }
-
-    // Not found in any map — should not normally happen,
-    // but GT code has insert-then-copy logic for maps 0/1
-    // We replicate by inserting into the appropriate map
-    int level = pInfo->gameLevel;
-    if (level >= 0 && level <= 4)
-    {
-        stPKRoomInfo* pNew = new stPKRoomInfo();
-        pNew->operator=((char*)pInfo);
-        m_mapRooms[level][handleID] = pNew;
-    }
+    // Not found in any map: GT 不會自行建立新房間，這裡也不做。
 }
 
 int cltPKManager::GetPKRoomNumByGameLevel(int a2)
@@ -605,7 +590,6 @@ int cltPKManager::CheckQuickJoinRoom(int gameLevel)
         return 0;
 
     m_iter = m_mapRooms[mapIdx].begin();
-    m_iterMapIdx = mapIdx;
 
     if (m_iter == m_mapRooms[mapIdx].end())
         return 0;


### PR DESCRIPTION
## Summary
This PR refactors the `cltPKManager` class to align with the original GT (mofclient.c) implementation, removing unnecessary state tracking and simplifying logic based on reverse-engineered behavior.

## Key Changes

- **Removed `m_iterMapIdx` member variable**: This field was tracking which map contained the current iterator, but GT doesn't maintain this state. The iterator `m_iter` is now always updated during searches, regardless of success.

- **Simplified `GetGameLevelByHandle()`**: Now unconditionally assigns the search result to `m_iter` for each map before checking if the element was found, matching GT's behavior at offset 199444.

- **Simplified `SetPKRoomInfoCreate()`**: Removed redundant self-assignment checks. Now performs only a simple pointer comparison (`if (pInfo == &m_currentRoom)`) as GT does at offset 199519.

- **Removed fallback room creation in `UpdatePKRoomInfo()`**: GT doesn't create new rooms when an update fails to find the target. Removed the insert-then-copy logic that was attempting to handle this case.

- **Cleaned up `CopyPKRoomInfoFromList()` and `CheckQuickJoinRoom()`**: Removed `m_iterMapIdx` assignments that are no longer needed.

- **Reorganized member variable layout**: Reordered members in the header to match GT's memory layout (offset +84 for `m_iter`, offset +88 for `m_currentRoom`), with detailed offset comments for future reference.

## Implementation Details

- Iterator state (`m_iter`) is now the single source of truth for tracking search results across method calls
- All search operations (find/lower_bound) now consistently write their results to `m_iter`
- Added detailed comments referencing GT offsets to facilitate future maintenance and verification
- Moved `m_currentRoom` to public section to maintain API compatibility while aligning with GT layout

https://claude.ai/code/session_01J3aqJty65zekTLvfE1CJ61