### PR TITLE
Add MoF character emulator with CA/GI parser and Tkinter UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ mofdata
 mof.pak
 mof.paki
 txt.tmp
+__pycache__/
+*.pyc

--- a/character_emulator/ca_loader.py
+++ b/character_emulator/ca_loader.py
@@ -1,0 +1,297 @@
+"""
+High-level loader that mirrors ``CAManager::LoadCADataDot`` /
+``LoadCADataIllust`` in mofclient.c.
+
+The MoF client keeps **17 ``TIMELINEINFO`` instances** for the dot character
+and 7 + 1 instances for the illust character. They are loaded by individual
+``CAManager::LoadTimeline`` calls (mofclient.c:245327-245383)::
+
+    Dot_Character_HAIR.ca           → slot 0  HAIR
+    Dot_Character_FACE.ca           → slot 1  FACE
+    Dot_Character_COAT.ca           → slot 2  COAT
+    Dot_Character_TRIUSERS.ca       → slot 3  TRIUSERS
+    Dot_Character_SHOES.ca          → slot 4  SHOES
+    Dot_Character_HAND.ca           → slot 5  HAND
+    Dot_Character_CLOCK.ca          → slot 6  CLOCK
+    Dot_Character_RIGHTHANDWEAPON.ca→ slot 7  RWEAPON
+    Dot_Character_LEFTHANDWEAPON.ca → slot 8  LWEAPON
+    Dot_Character_ACCESSORY1.ca     → slot 9  ACC1
+    Dot_Character_ACCESSORY2.ca     → slot 10 ACC2
+    Dot_Character_ACCESSORY3.ca     → slot 11 ACC3
+    Dot_Character_MASKHAIR.ca       → slot 12 MASKHAIR
+    Dot_Character_SUIT.ca           → slot 13 SUIT
+    Dot_Character_EMOTICON.ca       → slot 14 EMOTICON
+    Dot_Character_DUALWEAPON.ca     → slot 15 DUALWEAPON
+    Dot_Character.ca                → BASE (keys + animation timing)
+
+The ``Dot_Character.ca`` is the **base timeline**: it is the only file that is
+loaded with a non-NULL ``CANIMATIONINFO`` argument and therefore contains the
+animation key list (mofclient.c:245319-245323). Its 23 layers are also used as
+the *initial* contents of every CCA layer slot (mofclient.c:240785-240793).
+"""
+
+import os
+
+from parse_ca import parse_ca, CAFile
+from item_data import (
+    SLOT_HAIR, SLOT_FACE, SLOT_COAT, SLOT_TRIUSERS, SLOT_SHOES,
+    SLOT_HAND, SLOT_CLOCK, SLOT_RWEAPON, SLOT_LWEAPON,
+    SLOT_ACC1, SLOT_ACC2, SLOT_ACC3, SLOT_MASKHAIR, SLOT_SUIT,
+    SLOT_EMOTICON, SLOT_DUALWEAPON, SLOT_NAMES,
+)
+
+
+# ── File-name table for the dot character ────────────────────────────────────
+
+DOT_SLOT_FILES = [
+    (SLOT_HAIR,       'Dot_Character_HAIR.ca'),
+    (SLOT_FACE,       'Dot_Character_FACE.ca'),
+    (SLOT_COAT,       'Dot_Character_COAT.ca'),
+    (SLOT_TRIUSERS,   'Dot_Character_TRIUSERS.ca'),
+    (SLOT_SHOES,      'Dot_Character_SHOES.ca'),
+    (SLOT_HAND,       'Dot_Character_HAND.ca'),
+    (SLOT_CLOCK,      'Dot_Character_CLOCK.ca'),
+    (SLOT_RWEAPON,    'Dot_Character_RIGHTHANDWEAPON.ca'),
+    (SLOT_LWEAPON,    'Dot_Character_LEFTHANDWEAPON.ca'),
+    (SLOT_ACC1,       'Dot_Character_ACCESSORY1.ca'),
+    (SLOT_ACC2,       'Dot_Character_ACCESSORY2.ca'),
+    (SLOT_ACC3,       'Dot_Character_ACCESSORY3.ca'),
+    (SLOT_MASKHAIR,   'Dot_Character_MASKHAIR.ca'),
+    (SLOT_SUIT,       'Dot_Character_SUIT.ca'),
+    (SLOT_EMOTICON,   'Dot_Character_EMOTICON.ca'),
+    (SLOT_DUALWEAPON, 'Dot_Character_DUALWEAPON.ca'),
+]
+
+DOT_BASE_FILE = 'Dot_Character.ca'
+
+
+ILLUST_SLOT_FILES = [
+    (SLOT_HAIR,    'Illust_Character_HAIR.ca'),
+    (SLOT_FACE,    'Illust_Character_FACE.ca'),
+    (SLOT_COAT,    'Illust_Character_COAT.ca'),
+    (SLOT_TRIUSERS,'Illust_Character_TRIUSERS.ca'),
+    (SLOT_SHOES,   'Illust_Character_SHOES.ca'),
+    (SLOT_HAND,    'Illust_Character_HAND.ca'),
+]
+ILLUST_BASE_FILE = 'Illust_Character.ca'
+
+
+# ── Case-insensitive file lookup ──────────────────────────────────────────────
+
+def _find_file_ci(directory, name):
+    """Return the actual case-correct path for ``name`` inside ``directory``,
+    or None if no such file exists. Linux case-sensitivity workaround."""
+    if not os.path.isdir(directory):
+        return None
+    target = name.lower()
+    try:
+        for entry in os.listdir(directory):
+            if entry.lower() == target:
+                return os.path.join(directory, entry)
+    except OSError:
+        return None
+    return None
+
+
+def find_character_dir(mofdata_root):
+    """Locate the ``Character`` sub-directory under a MoFData root."""
+    for sub in ('character', 'Character', 'CHARACTER'):
+        path = os.path.join(mofdata_root, sub)
+        if os.path.isdir(path):
+            return path
+    if os.path.isdir(mofdata_root):
+        return mofdata_root
+    return None
+
+
+# ── Slot collection ───────────────────────────────────────────────────────────
+
+class SlotCA:
+    """One CA file backing a single slot category (HAIR, COAT, …)."""
+    __slots__ = ('slot_id', 'slot_name', 'filename', 'path', 'ca')
+
+    def __init__(self, slot_id, filename, path, ca):
+        self.slot_id = slot_id
+        self.slot_name = SLOT_NAMES.get(slot_id, '?')
+        self.filename = filename
+        self.path = path
+        self.ca = ca
+
+    @property
+    def num_layers(self):
+        return len(self.ca.layers) if self.ca else 0
+
+    def get_layer(self, idx):
+        if not self.ca or idx < 0 or idx >= len(self.ca.layers):
+            return None
+        return self.ca.layers[idx]
+
+
+class CharacterCA:
+    """Loaded set of CA files for the dot or illust character.
+
+    Attributes:
+        base   (CAFile):     the base timeline (Dot_Character.ca / Illust_Character.ca)
+        slots  (dict[int, SlotCA]): slot id → SlotCA
+        keys   (list[KeyInfo]):     animation key list (from base.keys)
+        anim_fps (int):            animation timing from base.anim_fps
+    """
+
+    def __init__(self, base=None):
+        self.base = base
+        self.slots = {}
+        self.character_dir = None
+
+    # — helpers ——
+    @property
+    def keys(self):
+        return self.base.keys if self.base else []
+
+    @property
+    def anim_fps(self):
+        return self.base.anim_fps if self.base else 0
+
+    @property
+    def max_frames(self):
+        return self.base.max_frames if self.base else 0
+
+    @property
+    def num_base_layers(self):
+        return len(self.base.layers) if self.base else 0
+
+    def get_slot(self, slot_id):
+        return self.slots.get(slot_id)
+
+    def get_layer(self, slot_id, layer_index):
+        slot = self.slots.get(slot_id)
+        if slot is None:
+            return None
+        return slot.get_layer(layer_index)
+
+    def find_key(self, name):
+        """Find an animation key by name (case-insensitive)."""
+        if not self.base:
+            return None
+        for k in self.base.keys:
+            if k.name == name or k.name.lower() == name.lower():
+                return k
+        return None
+
+
+# ── Loaders ───────────────────────────────────────────────────────────────────
+
+def _safe_parse(path):
+    try:
+        return parse_ca(path)
+    except Exception as e:
+        print('  [ca_loader] failed to parse %s: %s' % (path, e))
+        return None
+
+
+def load_character_dot(mofdata_root, verbose=False):
+    """Load the full dot character set from a MoFData root.
+
+    Mirrors ``CAManager::LoadCADataDot`` (mofclient.c:245180), minus the
+    text-mode ``CA_Character_Dot.txt`` step (use :func:`item_data.load_dot_items`
+    for that).
+    """
+    char_dir = find_character_dir(mofdata_root)
+    if char_dir is None:
+        raise FileNotFoundError(
+            'Could not find a Character directory under %r' % mofdata_root)
+
+    out = CharacterCA()
+    out.character_dir = char_dir
+
+    base_path = _find_file_ci(char_dir, DOT_BASE_FILE)
+    if base_path is None:
+        raise FileNotFoundError('%s not found in %s' % (DOT_BASE_FILE, char_dir))
+    out.base = _safe_parse(base_path)
+    if verbose:
+        print('  base   :', base_path,
+              '(layers=%d frames=%d keys=%d fps=%d)' %
+              (len(out.base.layers), out.base.max_frames,
+               len(out.base.keys), out.base.anim_fps))
+
+    for slot_id, fname in DOT_SLOT_FILES:
+        path = _find_file_ci(char_dir, fname)
+        if path is None:
+            if verbose:
+                print('  MISS  : slot %2d %s' % (slot_id, fname))
+            continue
+        ca = _safe_parse(path)
+        if ca is None:
+            continue
+        out.slots[slot_id] = SlotCA(slot_id, fname, path, ca)
+        if verbose:
+            print('  slot %2d %-12s : %s  layers=%d' %
+                  (slot_id, SLOT_NAMES.get(slot_id, '?'),
+                   os.path.basename(path), len(ca.layers)))
+    return out
+
+
+def load_character_illust(mofdata_root, verbose=False):
+    """Load the illust character set."""
+    char_dir = find_character_dir(mofdata_root)
+    if char_dir is None:
+        raise FileNotFoundError(
+            'Could not find a Character directory under %r' % mofdata_root)
+
+    out = CharacterCA()
+    out.character_dir = char_dir
+
+    base_path = _find_file_ci(char_dir, ILLUST_BASE_FILE)
+    if base_path is None:
+        raise FileNotFoundError(
+            '%s not found in %s' % (ILLUST_BASE_FILE, char_dir))
+    out.base = _safe_parse(base_path)
+    if verbose:
+        print('  base   :', base_path)
+
+    for slot_id, fname in ILLUST_SLOT_FILES:
+        path = _find_file_ci(char_dir, fname)
+        if path is None:
+            if verbose:
+                print('  MISS  : slot %2d %s' % (slot_id, fname))
+            continue
+        ca = _safe_parse(path)
+        if ca is None:
+            continue
+        out.slots[slot_id] = SlotCA(slot_id, fname, path, ca)
+        if verbose:
+            print('  slot %2d %-12s : %s' %
+                  (slot_id, SLOT_NAMES.get(slot_id, '?'),
+                   os.path.basename(path)))
+    return out
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Load and dump a MoF character CA set.')
+    parser.add_argument('mofdata', help='Path to the MoFData root directory')
+    parser.add_argument('--illust', action='store_true',
+                        help='Load the illust set instead of dot')
+    parser.add_argument('--keys', action='store_true',
+                        help='Dump animation keys')
+    args = parser.parse_args()
+
+    loader = load_character_illust if args.illust else load_character_dot
+    char = loader(args.mofdata, verbose=True)
+
+    print()
+    print('Total slots loaded :', len(char.slots))
+    print('Base max_frames    :', char.max_frames)
+    print('Base anim_fps      :', char.anim_fps)
+    print('Animation keys     :', len(char.keys))
+    if args.keys and char.keys:
+        for i, k in enumerate(char.keys):
+            print('  [%2d] %-20s frames=%d-%d (%d)'
+                  % (i, k.name, k.start_frame, k.end_frame,
+                     k.end_frame - k.start_frame + 1))
+
+
+if __name__ == '__main__':
+    main()

--- a/character_emulator/character_emulator.py
+++ b/character_emulator/character_emulator.py
@@ -1,0 +1,399 @@
+"""
+Tkinter UI for the MoF dot/illust character emulator.
+
+Run with::
+
+    python character_emulator.py /path/to/MoFData
+
+Or set ``MOFDATA_DIR`` in the environment and run with no arguments.
+
+Requirements: Python 3.8+, Pillow (``pip install Pillow``), tkinter (stdlib).
+
+Key bindings:
+    Space   pause / resume animation
+    Right   step one frame forwards (when paused)
+    Left    step one frame backwards (when paused)
+    1 / 2   switch between Dot and Illust modes (if illust files exist)
+"""
+
+import argparse
+import os
+import sys
+import time
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+try:
+    from PIL import Image, ImageTk
+except ImportError:
+    print('This UI requires Pillow:  pip install Pillow', file=sys.stderr)
+    raise
+
+from ca_loader import (
+    load_character_dot, load_character_illust,
+    DOT_SLOT_FILES, ILLUST_SLOT_FILES, find_character_dir,
+)
+from character_renderer import (
+    NUM_CCA_SLOTS, build_default_slots, apply_equipment, render_frame,
+    frame_index_for_key,
+)
+from gi_resource import GIResource
+from item_data import (
+    SLOT_NAMES, load_dot_items, load_illust_items, item_id_to_code,
+)
+
+
+CANVAS_W, CANVAS_H = 480, 560
+DEFAULT_FPS_FALLBACK = 12
+
+
+# ── A single equipment combobox row ──────────────────────────────────────────
+
+class SlotControl:
+    def __init__(self, parent, slot_id, slot_name, max_index, on_change):
+        self.slot_id = slot_id
+        self.slot_name = slot_name
+        self.max_index = max_index
+        self.var = tk.StringVar(value='(none)')
+        ttk.Label(parent, text='%-9s' % slot_name, width=10).grid(
+            row=slot_id, column=0, padx=2, pady=1, sticky='w')
+        values = ['(none)'] + [str(i) for i in range(max_index)]
+        self.combo = ttk.Combobox(parent, textvariable=self.var,
+                                  values=values, width=8, state='readonly')
+        self.combo.grid(row=slot_id, column=1, padx=2, pady=1, sticky='w')
+        self.combo.bind('<<ComboboxSelected>>', lambda e: on_change())
+
+    def get_index(self):
+        v = self.var.get()
+        if v == '(none)':
+            return None
+        try:
+            return int(v)
+        except ValueError:
+            return None
+
+    def set_index(self, idx):
+        self.var.set('(none)' if idx is None else str(idx))
+
+
+# ── Main application ─────────────────────────────────────────────────────────
+
+class CharacterEmulator:
+    def __init__(self, root, mofdata_dir):
+        self.root = root
+        self.mofdata_dir = mofdata_dir
+        self.character_dir = find_character_dir(mofdata_dir)
+        if self.character_dir is None:
+            raise FileNotFoundError(
+                'Could not find a Character directory under %r' % mofdata_dir)
+
+        self.gi_resource = GIResource(self.character_dir)
+        self.gi_resource.index()  # warm the directory listing
+
+        # Dot is the default; Illust loaded lazily on demand.
+        self.character = load_character_dot(mofdata_dir, verbose=True)
+        self.mode = 'dot'  # 'dot' or 'illust'
+
+        # Optional item-binding tables (display only — emulator works without).
+        self.item_table_dot    = self._try_load_items('CA_Character_Dot.txt',
+                                                      load_dot_items)
+        self.item_table_illust = self._try_load_items(
+            'CA_Character_illustration.txt', load_illust_items)
+
+        # Animation state
+        self.equipment = {}        # slot_id → layer_index
+        self.current_key_index = 0
+        self.tick = 0
+        self.playing = True
+        self.last_time = time.monotonic()
+
+        self._build_ui()
+        self._refresh_keys()
+        self._tick()
+
+    # — initialisation helpers ——
+    def _try_load_items(self, name, loader):
+        for sub in ('', 'Character', 'character'):
+            p = os.path.join(self.mofdata_dir, sub, name) if sub \
+                else os.path.join(self.mofdata_dir, name)
+            if os.path.isfile(p):
+                try:
+                    return loader(p)
+                except Exception as e:
+                    print('  [items] failed to read %s: %s' % (p, e))
+        return {}
+
+    # — UI construction ——
+    def _build_ui(self):
+        self.root.title('MoF Character Emulator')
+        self.root.minsize(820, 640)
+
+        # Left: equipment
+        left = ttk.LabelFrame(self.root, text='Equipment')
+        left.grid(row=0, column=0, padx=8, pady=8, sticky='ns')
+        self._build_equipment_pane(left)
+
+        # Centre: canvas + transport
+        centre = ttk.Frame(self.root)
+        centre.grid(row=0, column=1, padx=8, pady=8, sticky='nsew')
+        self.canvas = tk.Canvas(centre, width=CANVAS_W, height=CANVAS_H,
+                                bg='#202024', highlightthickness=1,
+                                highlightbackground='#444')
+        self.canvas.pack()
+        self._build_transport(centre)
+
+        # Right: animation key list + status
+        right = ttk.LabelFrame(self.root, text='Animation')
+        right.grid(row=0, column=2, padx=8, pady=8, sticky='ns')
+        self._build_anim_pane(right)
+
+        self.root.columnconfigure(1, weight=1)
+        self.root.rowconfigure(0, weight=1)
+
+        self.root.bind('<space>', lambda e: self._toggle_play())
+        self.root.bind('<Right>', lambda e: self._step(+1))
+        self.root.bind('<Left>',  lambda e: self._step(-1))
+        self.root.bind('1',       lambda e: self._switch_mode('dot'))
+        self.root.bind('2',       lambda e: self._switch_mode('illust'))
+
+    def _build_equipment_pane(self, parent):
+        self.slot_controls = {}
+        for slot_id, fname in DOT_SLOT_FILES:
+            slot_ca = self.character.get_slot(slot_id)
+            n_layers = len(slot_ca.ca.layers) if slot_ca else 0
+            ctl = SlotControl(parent, slot_id, SLOT_NAMES[slot_id],
+                              n_layers, self._on_equipment_change)
+            self.slot_controls[slot_id] = ctl
+
+        ttk.Separator(parent, orient='horizontal').grid(
+            row=NUM_CCA_SLOTS + 1, column=0, columnspan=2,
+            sticky='ew', pady=4)
+        ttk.Button(parent, text='Clear all',
+                   command=self._clear_equipment).grid(
+            row=NUM_CCA_SLOTS + 2, column=0, columnspan=2, pady=2)
+        ttk.Button(parent, text='By item code…',
+                   command=self._dialog_item_code).grid(
+            row=NUM_CCA_SLOTS + 3, column=0, columnspan=2, pady=2)
+
+    def _build_transport(self, parent):
+        bar = ttk.Frame(parent)
+        bar.pack(fill='x', pady=4)
+        self.play_btn = ttk.Button(bar, text='Pause',
+                                   command=self._toggle_play, width=8)
+        self.play_btn.pack(side='left', padx=4)
+        ttk.Button(bar, text='←', width=3,
+                   command=lambda: self._step(-1)).pack(side='left')
+        ttk.Button(bar, text='→', width=3,
+                   command=lambda: self._step(+1)).pack(side='left')
+        ttk.Button(bar, text='Reset', width=6,
+                   command=self._reset_tick).pack(side='left', padx=4)
+
+        self.frame_label = ttk.Label(bar, text='frame 0 / 0')
+        self.frame_label.pack(side='left', padx=8)
+
+        # Mode toggle
+        self.mode_var = tk.StringVar(value='dot')
+        ttk.Radiobutton(bar, text='Dot', value='dot', variable=self.mode_var,
+                        command=lambda: self._switch_mode('dot')).pack(side='right')
+        ttk.Radiobutton(bar, text='Illust', value='illust',
+                        variable=self.mode_var,
+                        command=lambda: self._switch_mode('illust')
+                        ).pack(side='right')
+
+        self.status = tk.StringVar(value='')
+        ttk.Label(parent, textvariable=self.status,
+                  foreground='#aaa').pack(anchor='w', padx=4, pady=(4, 0))
+
+    def _build_anim_pane(self, parent):
+        self.key_list = tk.Listbox(parent, height=22, width=22,
+                                   exportselection=False)
+        self.key_list.pack(fill='both', expand=True, padx=4, pady=4)
+        self.key_list.bind('<<ListboxSelect>>', self._on_key_select)
+        self.info_label = ttk.Label(parent, text='', foreground='#666',
+                                    justify='left', wraplength=180)
+        self.info_label.pack(anchor='w', padx=4, pady=4)
+
+    # — event handlers ——
+    def _refresh_keys(self):
+        self.key_list.delete(0, 'end')
+        keys = self.character.keys or []
+        if keys:
+            for i, k in enumerate(keys):
+                label = '%2d  %-12s [%d-%d]' % (
+                    i, (k.name or '').strip() or '(unnamed)',
+                    k.start_frame, k.end_frame)
+                self.key_list.insert('end', label)
+            if self.current_key_index >= len(keys):
+                self.current_key_index = 0
+            self.key_list.selection_set(self.current_key_index)
+        else:
+            self.key_list.insert('end', '(no keys)')
+            self.current_key_index = 0
+
+        slots_count = len(self.character.slots)
+        max_frames = self.character.max_frames or 0
+        anim_fps = self.character.anim_fps or 0
+        self.info_label.config(text=(
+            'mode      : %s\n'
+            'slot files: %d\n'
+            'max frames: %d\n'
+            'anim fps  : %d\n'
+            'gi atlas  : %d files'
+        ) % (self.mode, slots_count, max_frames, anim_fps,
+             len(self.gi_resource.index())))
+
+    def _on_key_select(self, _evt):
+        sel = self.key_list.curselection()
+        if not sel:
+            return
+        self.current_key_index = sel[0]
+        self.tick = 0
+
+    def _on_equipment_change(self):
+        self.equipment = {sid: ctl.get_index()
+                          for sid, ctl in self.slot_controls.items()
+                          if ctl.get_index() is not None}
+
+    def _clear_equipment(self):
+        for ctl in self.slot_controls.values():
+            ctl.set_index(None)
+        self.equipment = {}
+
+    def _dialog_item_code(self):
+        win = tk.Toplevel(self.root)
+        win.title('Equip by item code')
+        win.transient(self.root)
+        win.geometry('320x100')
+        ttk.Label(win, text='Item code (e.g. H0001):').pack(pady=(8, 2))
+        var = tk.StringVar()
+        entry = ttk.Entry(win, textvariable=var, width=12)
+        entry.pack(pady=2)
+        entry.focus_set()
+
+        def apply():
+            code = var.get().strip().upper()
+            table = (self.item_table_dot if self.mode == 'dot'
+                     else self.item_table_illust)
+            info = table.get(code)
+            if not info:
+                messagebox.showerror('Not found',
+                                     'Item code %r not in CA table.' % code)
+                return
+            if self.mode == 'dot':
+                if info.type1 in self.slot_controls:
+                    self.slot_controls[info.type1].set_index(info.layer_index1)
+                if info.type2 in self.slot_controls:
+                    self.slot_controls[info.type2].set_index(info.layer_index2)
+            else:
+                if info.type in self.slot_controls:
+                    self.slot_controls[info.type].set_index(info.frame_index)
+            self._on_equipment_change()
+            win.destroy()
+
+        ttk.Button(win, text='Apply', command=apply).pack(pady=4)
+        win.bind('<Return>', lambda e: apply())
+
+    def _toggle_play(self):
+        self.playing = not self.playing
+        self.play_btn.config(text='Play' if not self.playing else 'Pause')
+
+    def _step(self, delta):
+        self.playing = False
+        self.play_btn.config(text='Play')
+        self.tick += delta
+
+    def _reset_tick(self):
+        self.tick = 0
+
+    def _switch_mode(self, mode):
+        if mode == self.mode:
+            return
+        try:
+            if mode == 'dot':
+                self.character = load_character_dot(self.mofdata_dir)
+            else:
+                self.character = load_character_illust(self.mofdata_dir)
+        except Exception as e:
+            messagebox.showerror('Switch failed', str(e))
+            self.mode_var.set(self.mode)
+            return
+        self.mode = mode
+        self.mode_var.set(mode)
+        self._clear_equipment()
+        # Rebuild slot combos with new layer counts.
+        for slot_id, ctl in self.slot_controls.items():
+            slot_ca = self.character.get_slot(slot_id)
+            n = len(slot_ca.ca.layers) if slot_ca else 0
+            ctl.max_index = n
+            ctl.combo.config(values=['(none)'] + [str(i) for i in range(n)])
+        self.tick = 0
+        self.current_key_index = 0
+        self._refresh_keys()
+
+    # — main animation loop ——
+    def _tick(self):
+        # Advance frame counter
+        if self.playing:
+            self.tick += 1
+
+        keys = self.character.keys or []
+        key = keys[self.current_key_index] if keys else None
+        frame_index = frame_index_for_key(self.character, key, self.tick)
+
+        slots = build_default_slots(self.character)
+        apply_equipment(slots, self.character, self.equipment)
+        result = render_frame(slots, frame_index, self.gi_resource,
+                              canvas_size=(CANVAS_W, CANVAS_H))
+
+        # Draw
+        self._photo = ImageTk.PhotoImage(result.image)
+        self.canvas.delete('all')
+        self.canvas.create_image(0, 0, anchor='nw', image=self._photo)
+        # Crosshair at the character origin
+        ox, oy = result.origin_x, result.origin_y
+        self.canvas.create_line(ox - 8, oy, ox + 8, oy, fill='#666')
+        self.canvas.create_line(ox, oy - 8, ox, oy + 8, fill='#666')
+
+        max_frame = key.end_frame if key else self.character.max_frames - 1
+        min_frame = key.start_frame if key else 0
+        self.frame_label.config(text='frame %d / %d-%d  dots=%d  miss=%d'
+                                % (frame_index, min_frame, max_frame,
+                                   result.dot_count, len(result.missing_ids)))
+        if result.missing_ids:
+            sample = sorted(result.missing_ids)[:3]
+            self.status.set('missing GI: ' + ', '.join('%08X' % x for x in sample))
+        else:
+            self.status.set('')
+
+        # Schedule next tick
+        fps = self.character.anim_fps or DEFAULT_FPS_FALLBACK
+        delay = max(16, int(1000 / max(1, fps)))
+        self.root.after(delay, self._tick)
+
+
+# ── entry point ──────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='MoF dot/illust character emulator.')
+    parser.add_argument('mofdata', nargs='?',
+                        default=os.environ.get('MOFDATA_DIR', './mofdata'),
+                        help='Path to the MoFData directory '
+                             '(default: $MOFDATA_DIR or ./mofdata)')
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.mofdata):
+        sys.stderr.write('MoFData directory not found: %s\n' % args.mofdata)
+        sys.exit(1)
+
+    root = tk.Tk()
+    try:
+        app = CharacterEmulator(root, args.mofdata)
+    except Exception as e:
+        messagebox.showerror('Failed to initialise', str(e))
+        raise
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    main()

--- a/character_emulator/character_renderer.py
+++ b/character_emulator/character_renderer.py
@@ -1,0 +1,198 @@
+"""
+Composite renderer for one CCA frame.
+
+This is the Python port of the inner loop of ``CCA::Process(GameImage*)``
+(mofclient.c:240976).  For each of the 23 *layer slots* in the CCA, we look up
+the currently bound ``LAYERINFO``, fetch its frame at the current animation
+position, then draw every ``DOTINFO`` in that frame onto a single PIL canvas.
+
+The pivotal pieces of the original code we mirror::
+
+    v18 = 20 * v4;                       # frame index → byte offset
+    v20 = 32 * v19 + *(_DWORD *)(v17 + v18 + 4);    # &dot[i]
+    v45 = *(...) + 52 * *(WORD *)(v20 + 4);         # frame.subframe
+    v46 = (double)*(int *)(v45 + 28) + *(float *)(v20 + 8);  # x = sub.offX + dot.offX
+    v48 = (double)*(int *)(v45 + 32) + *(float *)(v20 + 12); # y = sub.offY + dot.offY
+
+So a single dot's screen position is::
+
+    pos = (subframe.offset_x + dot.offset_x + character_origin_x,
+           subframe.offset_y + dot.offset_y + character_origin_y)
+
+The "character origin" is just the centre of our PIL canvas: in the game it is
+``CCA::*((float*)this+32) / +33`` (the character's world position).
+
+The 23-slot CCA layer table starts as a copy of ``Dot_Character.ca``'s layers
+(mofclient.c:240785-240793). When an item is "equipped", ``CCA::LayerPutOn``
+overrides specific slot indices with layers from the per-category .ca file.
+We reproduce that mapping in :func:`apply_equipment` below — it is a
+straightforward translation of the C++ switch in mofclient.c:242019-242109.
+"""
+
+from item_data import (
+    SLOT_HAIR, SLOT_FACE, SLOT_COAT, SLOT_TRIUSERS, SLOT_SHOES,
+    SLOT_HAND, SLOT_CLOCK, SLOT_RWEAPON, SLOT_LWEAPON,
+    SLOT_ACC1, SLOT_ACC2, SLOT_ACC3, SLOT_MASKHAIR, SLOT_SUIT,
+    SLOT_EMOTICON, SLOT_DUALWEAPON, SLOT_NAMES,
+)
+
+
+# Total number of CCA layer slots, per mofclient.c:241594 (`while ( v13 < 0x17 );`)
+NUM_CCA_SLOTS = 23
+
+
+# ── Slot-table builder ───────────────────────────────────────────────────────
+
+def build_default_slots(character_ca):
+    """Return a 23-element list of base-character LAYERINFO objects.
+
+    Mirrors the loop at mofclient.c:240785-240793, which copies the first 23
+    layers of ``Dot_Character.ca`` into the CCA's layer slots.
+    """
+    layers = character_ca.base.layers if character_ca.base else []
+    slots = [None] * NUM_CCA_SLOTS
+    for i in range(min(NUM_CCA_SLOTS, len(layers))):
+        slots[i] = layers[i]
+    return slots
+
+
+# CCA-slot index → (slot_id, sub-layer offset relative to the item's
+# layer_index1).  Pulled directly from CCA::LayerPutOn in
+# mofclient.c:242019-242109.  Some categories paint multiple CCA slots from
+# consecutive layer indices.
+_PUT_ON_RULES = {
+    SLOT_HAIR:       [(7,  0), (19, 1)],                              # case 0
+    SLOT_FACE:       [(12, 0)],                                       # case 1
+    SLOT_COAT:       [(16, 0)],                                       # case 2
+    SLOT_TRIUSERS:   [(15, 0)],                                       # case 3
+    SLOT_SHOES:      [(14, 0)],                                       # case 4
+    SLOT_HAND:       [(10, 0), (25, 1)],                              # case 5
+    SLOT_CLOCK:      [(6,  0), (8,  1), (18, 2), (23, 3)],            # case 6
+    SLOT_RWEAPON:    [(24, 0), (27, 1)],                              # case 7
+    SLOT_LWEAPON:    [(9,  0), (26, 1)],                              # case 8
+    SLOT_ACC1:       [(13, 0)],                                       # case 9
+    SLOT_ACC2:       [(21, 0)],                                       # case 10
+    SLOT_ACC3:       [(22, 0)],                                       # case 11
+    SLOT_MASKHAIR:   [(20, 0)],                                       # case 12
+    SLOT_SUIT:       [(17, 0), (10, 1), (25, 2)],                     # case 13
+    SLOT_DUALWEAPON: [(11, 0), (24, 1), (27, 2)],                     # case 15
+}
+
+
+def apply_equipment(slots, character_ca, equipment):
+    """Override ``slots`` in-place with layers from equipped items.
+
+    ``equipment`` is a mapping ``slot_id → layer_index`` (e.g. picked by the
+    UI).  Mirrors a sequence of ``CCA::LayerPutOn`` calls.
+    """
+    for slot_id, layer_index in equipment.items():
+        if layer_index is None or layer_index < 0:
+            continue
+        rules = _PUT_ON_RULES.get(slot_id)
+        if not rules:
+            continue
+        slot_ca = character_ca.get_slot(slot_id)
+        if slot_ca is None:
+            continue
+        for cca_slot_index, sub_offset in rules:
+            layer = slot_ca.get_layer(layer_index + sub_offset)
+            if layer is not None:
+                slots[cca_slot_index] = layer
+    return slots
+
+
+# ── Renderer ──────────────────────────────────────────────────────────────────
+
+class RenderResult:
+    __slots__ = ('image', 'origin_x', 'origin_y', 'dot_count', 'missing_ids')
+
+    def __init__(self, image, origin_x, origin_y, dot_count, missing_ids):
+        self.image = image
+        self.origin_x = origin_x
+        self.origin_y = origin_y
+        self.dot_count = dot_count
+        self.missing_ids = missing_ids
+
+
+def render_frame(slots, frame_index, gi_resource,
+                 canvas_size=(400, 500),
+                 origin=None,
+                 background=(0, 0, 0, 0)):
+    """Render a single composite frame.
+
+    Args:
+        slots:       list[LAYERINFO|None] — one entry per CCA slot.
+        frame_index: int — current animation frame (within the layer).
+        gi_resource: :class:`gi_resource.GIResource`.
+        canvas_size: (w, h) of the output image.
+        origin:      (x, y) world origin in canvas pixels. Defaults to the
+                     bottom-centre, which roughly matches how the engine
+                     anchors a character's feet.
+        background:  RGBA fill colour.
+
+    Returns:
+        :class:`RenderResult`.
+    """
+    from PIL import Image
+
+    canvas_w, canvas_h = canvas_size
+    if origin is None:
+        origin = (canvas_w // 2, canvas_h * 3 // 4)
+    ox, oy = origin
+
+    canvas = Image.new('RGBA', canvas_size, background)
+    dot_count = 0
+    missing_ids = set()
+
+    for slot_idx, layer in enumerate(slots):
+        if layer is None or not layer.frames:
+            continue
+        if frame_index < 0 or frame_index >= len(layer.frames):
+            continue
+        frame = layer.frames[frame_index]
+        if not frame.dots:
+            continue
+        for dot in frame.dots:
+            if dot.image_id == 0:
+                continue
+            gi = gi_resource.get(dot.image_id)
+            if gi is None:
+                missing_ids.add(dot.image_id)
+                continue
+            sub = gi.get_frame_image(dot.frame_index)
+            if sub is None:
+                continue
+            anim = gi.frames[dot.frame_index] if dot.frame_index < len(gi.frames) else None
+            if anim is None:
+                continue
+            # See CCA::Process @ mofclient.c:241541-241547 :
+            #   x = sub.offset_x + dot.offset_x + character_x
+            #   y = sub.offset_y + dot.offset_y + character_y
+            x = ox + anim.offset_x + int(round(dot.offset_x))
+            y = oy + anim.offset_y + int(round(dot.offset_y))
+            # Apply per-dot alpha if non-default
+            paste = sub
+            if dot.alpha != 255 and dot.alpha is not None:
+                a = max(0, min(255, dot.alpha))
+                if a == 0:
+                    continue
+                paste = sub.copy()
+                # Pre-multiply alpha channel
+                alpha_band = paste.split()[3].point(lambda v, a=a: v * a // 255)
+                paste.putalpha(alpha_band)
+            canvas.alpha_composite(paste, (x, y))
+            dot_count += 1
+
+    return RenderResult(canvas, ox, oy, dot_count, missing_ids)
+
+
+# ── Convenience: pick frame index from animation key + tick ──────────────────
+
+def frame_index_for_key(character_ca, key, tick):
+    """Return the absolute frame index for ``tick`` ticks into a key."""
+    if key is None:
+        return tick % max(1, character_ca.max_frames)
+    span = key.end_frame - key.start_frame + 1
+    if span <= 0:
+        return key.start_frame
+    return key.start_frame + (tick % span)

--- a/character_emulator/gi_parser.py
+++ b/character_emulator/gi_parser.py
@@ -1,0 +1,622 @@
+"""
+GI (Game Image) file parser for MoF.
+
+Binary format reverse-engineered from:
+  - inc/Image/ImageResource.h
+  - src/Image/ImageResource.cpp  (LoadGI / LoadGIInPack)
+  - src/Image/Comp.cpp           (run_length_decomp)
+
+Header layout::
+
+    +0  uint32  version          (10 = uncompressed, 20 = RLE compressed)
+    +4  uint16  width
+    +6  uint16  height
+    +8  uint32  imageDataSize    (v10: raw size; v20: decompressed size)
+    +12 uint32  d3dFormat        (D3DFORMAT enum)
+    +16 uint16  animationFrameCount
+    +18 AnimationFrameData[animationFrameCount]   (52 bytes each)
+    -- v20: pixel stream follows directly (RLE compressed)
+    -- v10: 1 byte unknownFlag, then pixel stream
+
+AnimationFrameData (52 bytes)::
+
+    +0  uint32 unknown[3]
+    +12 int32  legacy_offsetX
+    +16 int32  legacy_offsetY
+    +20 int32  width
+    +24 int32  height
+    +28 int32  offsetX           (used for sprite drawing offset)
+    +32 int32  offsetY
+    +36 float  u1
+    +40 float  v1
+    +44 float  u2
+    +48 float  v2
+
+Public API::
+
+    from gi_parser import parse_gi, GIFile, render_frame_to_pil
+
+    gi = parse_gi("MoFData/Character/02000001_Dot_Character.gi")
+    print(gi.width, gi.height, gi.frame_count, gi.format_name)
+    pil_atlas = gi.to_pil_image()                  # the whole atlas
+    pil_subframe = gi.get_frame_image(frame_index) # one subframe (with offset)
+
+"""
+
+import os
+import struct
+from io import BytesIO
+
+
+# ── D3DFORMAT constants ───────────────────────────────────────────────────────
+# Only the subset that appears in MoF assets
+
+D3DFMT_UNKNOWN     = 0
+D3DFMT_R8G8B8      = 20
+D3DFMT_A8R8G8B8    = 21
+D3DFMT_X8R8G8B8    = 22
+D3DFMT_R5G6B5      = 23
+D3DFMT_X1R5G5B5    = 24
+D3DFMT_A1R5G5B5    = 25
+D3DFMT_A4R4G4B4    = 26
+D3DFMT_A8          = 28
+D3DFMT_X4R4G4B4    = 30
+D3DFMT_A8R3G3B2    = 29
+D3DFMT_A8L8        = 51
+
+# DXT formats use FourCC encoded as little-endian DWORD
+def _fourcc(s):
+    return (ord(s[3]) << 24) | (ord(s[2]) << 16) | (ord(s[1]) << 8) | ord(s[0])
+
+D3DFMT_DXT1 = _fourcc('DXT1')
+D3DFMT_DXT2 = _fourcc('DXT2')
+D3DFMT_DXT3 = _fourcc('DXT3')
+D3DFMT_DXT4 = _fourcc('DXT4')
+D3DFMT_DXT5 = _fourcc('DXT5')
+
+_FORMAT_NAMES = {
+    D3DFMT_A8R8G8B8: 'A8R8G8B8',
+    D3DFMT_X8R8G8B8: 'X8R8G8B8',
+    D3DFMT_R5G6B5:   'R5G6B5',
+    D3DFMT_A1R5G5B5: 'A1R5G5B5',
+    D3DFMT_A4R4G4B4: 'A4R4G4B4',
+    D3DFMT_R8G8B8:   'R8G8B8',
+    D3DFMT_A8:       'A8',
+    D3DFMT_DXT1:     'DXT1',
+    D3DFMT_DXT2:     'DXT2',
+    D3DFMT_DXT3:     'DXT3',
+    D3DFMT_DXT4:     'DXT4',
+    D3DFMT_DXT5:     'DXT5',
+}
+
+
+def get_pixel_depth(fmt):
+    """Bytes per pixel (or 1 for DXT block formats — same as the C++ helper)."""
+    if fmt in (D3DFMT_A8R8G8B8, D3DFMT_X8R8G8B8, D3DFMT_R8G8B8):
+        return 4
+    if fmt in (D3DFMT_R5G6B5, D3DFMT_A1R5G5B5, D3DFMT_X1R5G5B5,
+               D3DFMT_A4R4G4B4, D3DFMT_X4R4G4B4, D3DFMT_A8R3G3B2,
+               D3DFMT_A8L8):
+        return 2
+    if fmt in (D3DFMT_A8,):
+        return 1
+    if fmt in (D3DFMT_DXT1, D3DFMT_DXT2, D3DFMT_DXT3, D3DFMT_DXT4, D3DFMT_DXT5):
+        return 1  # marker — actual block decode happens elsewhere
+    return 0
+
+
+# ── RLE decompression (matches Comp.cpp::decomp_byte/word/dword) ─────────────
+
+_MARKER_BYTE  = 0xB4
+_MARKER_WORD  = 0xB4B4
+_MARKER_DWORD = 0xB4B4B4B4
+
+
+def decomp_byte(data, out_size):
+    out = bytearray(out_size)
+    rd = 0
+    wr = 0
+    n = len(data)
+    while rd < n and wr < out_size:
+        b = data[rd]; rd += 1
+        if b == _MARKER_BYTE:
+            nxt = data[rd]; rd += 1
+            if nxt == _MARKER_BYTE:
+                out[wr] = _MARKER_BYTE
+                wr += 1
+            else:
+                count = data[rd]; rd += 1
+                end = wr + count
+                if end > out_size:
+                    end = out_size
+                for k in range(wr, end):
+                    out[k] = nxt
+                wr = end
+        else:
+            out[wr] = b
+            wr += 1
+    return bytes(out)
+
+
+def decomp_word(data, out_size):
+    out = bytearray(out_size)
+    total_words = len(data) // 2
+    rd = 0  # word index
+    wr = 0  # byte offset
+    while rd < total_words and wr < out_size:
+        cur = struct.unpack_from('<H', data, rd * 2)[0]
+        rd += 1
+        if cur == _MARKER_WORD:
+            value = struct.unpack_from('<H', data, rd * 2)[0]
+            rd += 1
+            if value == _MARKER_WORD:
+                struct.pack_into('<H', out, wr, _MARKER_WORD)
+                wr += 2
+            else:
+                count = struct.unpack_from('<H', data, rd * 2)[0]
+                rd += 1
+                for _ in range(count):
+                    if wr + 2 > out_size:
+                        break
+                    struct.pack_into('<H', out, wr, value)
+                    wr += 2
+        else:
+            if wr + 2 <= out_size:
+                struct.pack_into('<H', out, wr, cur)
+            wr += 2
+    return bytes(out)
+
+
+def decomp_dword(data, out_size):
+    out = bytearray(out_size)
+    total_dwords = len(data) // 4
+    rd = 0
+    wr = 0
+    while rd < total_dwords and wr < out_size:
+        cur = struct.unpack_from('<I', data, rd * 4)[0]
+        rd += 1
+        if cur == _MARKER_DWORD:
+            value = struct.unpack_from('<I', data, rd * 4)[0]
+            rd += 1
+            if value == _MARKER_DWORD:
+                struct.pack_into('<I', out, wr, _MARKER_DWORD)
+                wr += 4
+            else:
+                count = struct.unpack_from('<I', data, rd * 4)[0]
+                rd += 1
+                for _ in range(count):
+                    if wr + 4 > out_size:
+                        break
+                    struct.pack_into('<I', out, wr, value)
+                    wr += 4
+        else:
+            if wr + 4 <= out_size:
+                struct.pack_into('<I', out, wr, cur)
+            wr += 4
+    return bytes(out)
+
+
+def run_length_decomp(data, out_size, unit):
+    if unit == 1:
+        return decomp_byte(data, out_size)
+    if unit == 2:
+        return decomp_word(data, out_size)
+    if unit == 4:
+        return decomp_dword(data, out_size)
+    raise ValueError('Unsupported RLE unit: %d' % unit)
+
+
+# ── Pixel format → RGBA conversion ────────────────────────────────────────────
+
+def _convert_a8r8g8b8(data, w, h):
+    """Direct3D A8R8G8B8 = little-endian BGRA in memory."""
+    rgba = bytearray(w * h * 4)
+    end = w * h * 4
+    src = memoryview(data)
+    for i in range(0, end, 4):
+        if i + 4 > len(src):
+            break
+        b = src[i]
+        g = src[i + 1]
+        r = src[i + 2]
+        a = src[i + 3]
+        rgba[i]     = r
+        rgba[i + 1] = g
+        rgba[i + 2] = b
+        rgba[i + 3] = a
+    return bytes(rgba)
+
+
+def _convert_x8r8g8b8(data, w, h):
+    """Same layout as A8R8G8B8, but alpha is ignored — force 255."""
+    rgba = bytearray(w * h * 4)
+    end = w * h * 4
+    src = memoryview(data)
+    for i in range(0, end, 4):
+        if i + 4 > len(src):
+            break
+        rgba[i]     = src[i + 2]
+        rgba[i + 1] = src[i + 1]
+        rgba[i + 2] = src[i]
+        rgba[i + 3] = 255
+    return bytes(rgba)
+
+
+def _convert_a1r5g5b5(data, w, h):
+    rgba = bytearray(w * h * 4)
+    for i in range(w * h):
+        if i * 2 + 2 > len(data):
+            break
+        v = struct.unpack_from('<H', data, i * 2)[0]
+        a = 255 if (v & 0x8000) else 0
+        r = ((v >> 10) & 0x1F) * 255 // 31
+        g = ((v >> 5)  & 0x1F) * 255 // 31
+        b = (v         & 0x1F) * 255 // 31
+        rgba[i*4 + 0] = r
+        rgba[i*4 + 1] = g
+        rgba[i*4 + 2] = b
+        rgba[i*4 + 3] = a
+    return bytes(rgba)
+
+
+def _convert_a4r4g4b4(data, w, h):
+    rgba = bytearray(w * h * 4)
+    for i in range(w * h):
+        if i * 2 + 2 > len(data):
+            break
+        v = struct.unpack_from('<H', data, i * 2)[0]
+        a = ((v >> 12) & 0xF) * 17
+        r = ((v >> 8)  & 0xF) * 17
+        g = ((v >> 4)  & 0xF) * 17
+        b = (v         & 0xF) * 17
+        rgba[i*4 + 0] = r
+        rgba[i*4 + 1] = g
+        rgba[i*4 + 2] = b
+        rgba[i*4 + 3] = a
+    return bytes(rgba)
+
+
+def _convert_r5g6b5(data, w, h):
+    rgba = bytearray(w * h * 4)
+    for i in range(w * h):
+        if i * 2 + 2 > len(data):
+            break
+        v = struct.unpack_from('<H', data, i * 2)[0]
+        r = ((v >> 11) & 0x1F) * 255 // 31
+        g = ((v >> 5)  & 0x3F) * 255 // 63
+        b = (v         & 0x1F) * 255 // 31
+        rgba[i*4 + 0] = r
+        rgba[i*4 + 1] = g
+        rgba[i*4 + 2] = b
+        rgba[i*4 + 3] = 255
+    return bytes(rgba)
+
+
+# ── DXT decompression (DXT1 / DXT3 / DXT5) ────────────────────────────────────
+
+def _unpack_565(c):
+    r = ((c >> 11) & 0x1F) * 255 // 31
+    g = ((c >> 5)  & 0x3F) * 255 // 63
+    b = (c         & 0x1F) * 255 // 31
+    return r, g, b
+
+
+def _decode_dxt1_block(block):
+    """Decode one 8-byte DXT1 block to a 4×4 RGBA buffer (64 bytes)."""
+    c0, c1 = struct.unpack_from('<HH', block, 0)
+    bits = struct.unpack_from('<I', block, 4)[0]
+    r0, g0, b0 = _unpack_565(c0)
+    r1, g1, b1 = _unpack_565(c1)
+    if c0 > c1:
+        r2 = (2 * r0 + r1) // 3
+        g2 = (2 * g0 + g1) // 3
+        b2 = (2 * b0 + b1) // 3
+        r3 = (r0 + 2 * r1) // 3
+        g3 = (g0 + 2 * g1) // 3
+        b3 = (b0 + 2 * b1) // 3
+        a0 = a1 = a2 = a3 = 255
+    else:
+        r2 = (r0 + r1) // 2
+        g2 = (g0 + g1) // 2
+        b2 = (b0 + b1) // 2
+        r3 = g3 = b3 = 0
+        a0 = a1 = a2 = 255
+        a3 = 0
+    palette = [
+        (r0, g0, b0, a0),
+        (r1, g1, b1, a1),
+        (r2, g2, b2, a2),
+        (r3, g3, b3, a3),
+    ]
+    out = bytearray(64)
+    for y in range(4):
+        for x in range(4):
+            idx = (bits >> (2 * (4 * y + x))) & 0x3
+            r, g, b, a = palette[idx]
+            o = (y * 4 + x) * 4
+            out[o]     = r
+            out[o + 1] = g
+            out[o + 2] = b
+            out[o + 3] = a
+    return out
+
+
+def _decode_dxt3_block(block):
+    alpha_data = struct.unpack_from('<Q', block, 0)[0]
+    out = _decode_dxt1_block(block[8:])
+    for y in range(4):
+        for x in range(4):
+            a4 = (alpha_data >> (4 * (4 * y + x))) & 0xF
+            o = (y * 4 + x) * 4 + 3
+            out[o] = a4 * 17
+    return out
+
+
+def _decode_dxt5_block(block):
+    a0 = block[0]
+    a1 = block[1]
+    abits = (block[2] | (block[3] << 8) | (block[4] << 16) |
+             (block[5] << 24) | (block[6] << 32) | (block[7] << 40))
+    if a0 > a1:
+        alphas = [a0, a1,
+                  (6 * a0 + 1 * a1) // 7,
+                  (5 * a0 + 2 * a1) // 7,
+                  (4 * a0 + 3 * a1) // 7,
+                  (3 * a0 + 4 * a1) // 7,
+                  (2 * a0 + 5 * a1) // 7,
+                  (1 * a0 + 6 * a1) // 7]
+    else:
+        alphas = [a0, a1,
+                  (4 * a0 + 1 * a1) // 5,
+                  (3 * a0 + 2 * a1) // 5,
+                  (2 * a0 + 3 * a1) // 5,
+                  (1 * a0 + 4 * a1) // 5,
+                  0, 255]
+    out = _decode_dxt1_block(block[8:])
+    for y in range(4):
+        for x in range(4):
+            ai = (abits >> (3 * (4 * y + x))) & 0x7
+            o = (y * 4 + x) * 4 + 3
+            out[o] = alphas[ai]
+    return out
+
+
+def _decode_dxt(data, w, h, decoder, block_size):
+    """Common DXT block decoder. Each block is 4×4 pixels."""
+    rgba = bytearray(w * h * 4)
+    bw = max(1, (w + 3) // 4)
+    bh = max(1, (h + 3) // 4)
+    pos = 0
+    for by in range(bh):
+        for bx in range(bw):
+            if pos + block_size > len(data):
+                return bytes(rgba)
+            block = data[pos:pos + block_size]
+            pos += block_size
+            decoded = decoder(block)
+            for y in range(4):
+                py = by * 4 + y
+                if py >= h:
+                    continue
+                for x in range(4):
+                    px = bx * 4 + x
+                    if px >= w:
+                        continue
+                    src = (y * 4 + x) * 4
+                    dst = (py * w + px) * 4
+                    rgba[dst]     = decoded[src]
+                    rgba[dst + 1] = decoded[src + 1]
+                    rgba[dst + 2] = decoded[src + 2]
+                    rgba[dst + 3] = decoded[src + 3]
+    return bytes(rgba)
+
+
+def to_rgba(data, w, h, fmt):
+    """Convert raw pixel data (already decompressed) to an RGBA byte buffer."""
+    if fmt == D3DFMT_A8R8G8B8:
+        return _convert_a8r8g8b8(data, w, h)
+    if fmt == D3DFMT_X8R8G8B8:
+        return _convert_x8r8g8b8(data, w, h)
+    if fmt == D3DFMT_R5G6B5:
+        return _convert_r5g6b5(data, w, h)
+    if fmt == D3DFMT_A1R5G5B5:
+        return _convert_a1r5g5b5(data, w, h)
+    if fmt == D3DFMT_A4R4G4B4:
+        return _convert_a4r4g4b4(data, w, h)
+    if fmt == D3DFMT_DXT1:
+        return _decode_dxt(data, w, h, _decode_dxt1_block, 8)
+    if fmt == D3DFMT_DXT3:
+        return _decode_dxt(data, w, h, _decode_dxt3_block, 16)
+    if fmt == D3DFMT_DXT5:
+        return _decode_dxt(data, w, h, _decode_dxt5_block, 16)
+    raise ValueError('Unsupported D3DFORMAT: 0x%X (%s)' %
+                     (fmt, _FORMAT_NAMES.get(fmt, '?')))
+
+
+# ── Data classes ──────────────────────────────────────────────────────────────
+
+ANIMATION_FRAME_FMT = '<3i' '2i' '2i' '2i' '4f'
+ANIMATION_FRAME_SIZE = 52
+assert struct.calcsize(ANIMATION_FRAME_FMT) == ANIMATION_FRAME_SIZE
+
+
+class AnimationFrame:
+    __slots__ = ('unknown0', 'unknown1', 'unknown2',
+                 'legacy_offset_x', 'legacy_offset_y',
+                 'width', 'height',
+                 'offset_x', 'offset_y',
+                 'u1', 'v1', 'u2', 'v2')
+
+    def __init__(self, data, off):
+        (self.unknown0, self.unknown1, self.unknown2,
+         self.legacy_offset_x, self.legacy_offset_y,
+         self.width, self.height,
+         self.offset_x, self.offset_y,
+         self.u1, self.v1, self.u2, self.v2) = struct.unpack_from(
+            ANIMATION_FRAME_FMT, data, off)
+
+    def __repr__(self):
+        return ('AnimationFrame(size=%dx%d, off=(%d,%d), uv=(%.3f,%.3f)-(%.3f,%.3f))'
+                % (self.width, self.height, self.offset_x, self.offset_y,
+                   self.u1, self.v1, self.u2, self.v2))
+
+
+class GIFile:
+    """Parsed GI image."""
+
+    def __init__(self):
+        self.version = 0
+        self.width = 0
+        self.height = 0
+        self.image_data_size = 0
+        self.decompressed_size = 0
+        self.d3d_format = 0
+        self.frame_count = 0
+        self.frames = []        # list[AnimationFrame]
+        self.unknown_flag = 0
+        self.pixel_data = b''   # raw decompressed pixel bytes
+        self._rgba_cache = None
+        self._pil_cache = None
+
+    @property
+    def format_name(self):
+        return _FORMAT_NAMES.get(self.d3d_format, '0x%X' % self.d3d_format)
+
+    def to_rgba(self):
+        if self._rgba_cache is None:
+            self._rgba_cache = to_rgba(self.pixel_data,
+                                       self.width, self.height,
+                                       self.d3d_format)
+        return self._rgba_cache
+
+    def to_pil_image(self):
+        """Return a PIL Image of the entire texture atlas."""
+        if self._pil_cache is None:
+            from PIL import Image  # local import — Pillow is optional
+            self._pil_cache = Image.frombytes('RGBA',
+                                              (self.width, self.height),
+                                              self.to_rgba())
+        return self._pil_cache
+
+    def get_frame_image(self, idx):
+        """Crop one animation frame from the atlas using its UV coordinates.
+
+        Returns a PIL Image of size (frame.width, frame.height). If UV is zero
+        or invalid, returns None.
+        """
+        if idx < 0 or idx >= len(self.frames):
+            return None
+        f = self.frames[idx]
+        if f.width <= 0 or f.height <= 0:
+            return None
+        u1 = max(0.0, min(1.0, f.u1))
+        v1 = max(0.0, min(1.0, f.v1))
+        u2 = max(0.0, min(1.0, f.u2))
+        v2 = max(0.0, min(1.0, f.v2))
+        x1 = int(round(u1 * self.width))
+        y1 = int(round(v1 * self.height))
+        x2 = int(round(u2 * self.width))
+        y2 = int(round(v2 * self.height))
+        if x2 <= x1 or y2 <= y1:
+            return None
+        atlas = self.to_pil_image()
+        return atlas.crop((x1, y1, x2, y2))
+
+
+# ── Parser ────────────────────────────────────────────────────────────────────
+
+def parse_gi_bytes(data):
+    """Parse a GI file from a raw byte buffer.
+
+    Mirrors ImageResource::LoadGI in src/Image/ImageResource.cpp.
+    """
+    gi = GIFile()
+    off = 0
+    gi.version          = struct.unpack_from('<I', data, off)[0]; off += 4
+    if gi.version not in (10, 20):
+        raise ValueError('Bad GI version: %d' % gi.version)
+    gi.width            = struct.unpack_from('<H', data, off)[0]; off += 2
+    gi.height           = struct.unpack_from('<H', data, off)[0]; off += 2
+    gi.image_data_size  = struct.unpack_from('<I', data, off)[0]; off += 4
+    gi.d3d_format       = struct.unpack_from('<I', data, off)[0]; off += 4
+    gi.frame_count      = struct.unpack_from('<H', data, off)[0]; off += 2
+
+    if gi.frame_count > 10000:
+        raise ValueError('Implausible animationFrameCount: %d' % gi.frame_count)
+
+    for i in range(gi.frame_count):
+        gi.frames.append(AnimationFrame(data, off))
+        off += ANIMATION_FRAME_SIZE
+
+    is_compressed = (gi.version == 20)
+
+    if is_compressed:
+        # v20: raw compressed stream follows directly. m_imageDataSize is the
+        # decompressed size; the compressed payload runs to EOF.
+        gi.decompressed_size = gi.image_data_size
+        compressed = data[off:]
+        unit = max(1, get_pixel_depth(gi.d3d_format))
+        # DXT formats use byte-stream RLE (unit=1).
+        if gi.d3d_format in (D3DFMT_DXT1, D3DFMT_DXT2, D3DFMT_DXT3,
+                             D3DFMT_DXT4, D3DFMT_DXT5):
+            unit = 1
+        gi.pixel_data = run_length_decomp(compressed, gi.decompressed_size, unit)
+    else:
+        # v10: 1 byte unknownFlag, then raw pixel data
+        gi.unknown_flag = data[off]; off += 1
+        if gi.image_data_size > 0:
+            gi.pixel_data = data[off:off + gi.image_data_size]
+        else:
+            gi.pixel_data = b''
+
+    return gi
+
+
+def parse_gi(filepath):
+    with open(filepath, 'rb') as f:
+        data = f.read()
+    return parse_gi_bytes(data)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description='Parse a MoF .gi image file.')
+    parser.add_argument('files', nargs='+')
+    parser.add_argument('--save-png', action='store_true',
+                        help='Write the decoded atlas next to the .gi file')
+    parser.add_argument('--dump-frames', action='store_true',
+                        help='Print every AnimationFrameData entry')
+    args = parser.parse_args()
+
+    for fp in args.files:
+        print('=' * 70)
+        print(' ', fp)
+        print('=' * 70)
+        try:
+            gi = parse_gi(fp)
+        except Exception as e:
+            print('  ERROR:', e)
+            continue
+        print('  Version : %d  (%s)' % (gi.version,
+              'compressed' if gi.version == 20 else 'raw'))
+        print('  Size    : %dx%d' % (gi.width, gi.height))
+        print('  Format  : %s (0x%X)' % (gi.format_name, gi.d3d_format))
+        print('  Frames  : %d' % gi.frame_count)
+        print('  Pixels  : %d bytes' % len(gi.pixel_data))
+        if args.dump_frames:
+            for i, f in enumerate(gi.frames):
+                print('    [%3d] %r' % (i, f))
+        if args.save_png:
+            try:
+                img = gi.to_pil_image()
+                out_path = os.path.splitext(fp)[0] + '.png'
+                img.save(out_path)
+                print('  Saved   :', out_path)
+            except Exception as e:
+                print('  PNG save failed:', e)
+
+
+if __name__ == '__main__':
+    main()

--- a/character_emulator/gi_resource.py
+++ b/character_emulator/gi_resource.py
@@ -1,0 +1,92 @@
+"""
+GI image cache + lookup (analogue of ``cltGIResource`` and ``cltImageManager``).
+
+The dot character Process loop in mofclient.c:241121 calls::
+
+    cltImageManager::GetGameImage(0, *(_DWORD *)v20, 0, 0)
+
+where ``*(DWORD*)v20`` is the ``image_id`` field stored in each ``DOTINFO``.
+The loaded resource is then accessed for its frame metadata (52-byte
+``AnimationFrameData`` array) and its texture data.
+
+In the engine, group 0 maps to ``MoFData/Character`` (mofclient.c:269275),
+and the on-disk filename is ``%08X_*.gi``. We replicate that here, with
+case-insensitive matching to be friendly to Linux file systems.
+"""
+
+import os
+
+from gi_parser import parse_gi
+
+
+class GIResource:
+    """Loads .gi files lazily on demand from a single base directory.
+
+    Mirrors ``cltGIResource::LoadResource`` (src/Image/cltGIResource.cpp:85).
+    """
+
+    def __init__(self, base_dir):
+        self.base_dir = base_dir
+        self._index = None
+        self._cache = {}      # id (int) → GIFile
+        self._missing = set() # id (int) — failed lookups, never retried
+
+    # — directory index ——
+    def _build_index(self):
+        """Build a dict ``id → absolute path`` by scanning ``base_dir``."""
+        index = {}
+        if not os.path.isdir(self.base_dir):
+            self._index = index
+            return
+        try:
+            for name in os.listdir(self.base_dir):
+                if not name.lower().endswith('.gi'):
+                    continue
+                # filename is "%08X_<rest>.gi". Try to parse the leading hex.
+                head = name.split('_', 1)[0]
+                if len(head) < 8:
+                    continue
+                try:
+                    res_id = int(head[:8], 16)
+                except ValueError:
+                    continue
+                index.setdefault(res_id, os.path.join(self.base_dir, name))
+        except OSError:
+            pass
+        self._index = index
+
+    def index(self):
+        if self._index is None:
+            self._build_index()
+        return self._index
+
+    def list_ids(self):
+        return sorted(self.index().keys())
+
+    # — lookup ——
+    def find_path(self, image_id):
+        return self.index().get(image_id)
+
+    def get(self, image_id):
+        """Return a parsed :class:`gi_parser.GIFile`, or None if not found."""
+        if image_id in self._cache:
+            return self._cache[image_id]
+        if image_id in self._missing:
+            return None
+        path = self.find_path(image_id)
+        if path is None:
+            self._missing.add(image_id)
+            return None
+        try:
+            gi = parse_gi(path)
+        except Exception as e:
+            print('  [gi_resource] failed to parse %08X (%s): %s'
+                  % (image_id, path, e))
+            self._missing.add(image_id)
+            return None
+        self._cache[image_id] = gi
+        return gi
+
+    def clear_cache(self):
+        self._cache.clear()
+        self._missing.clear()

--- a/character_emulator/item_data.py
+++ b/character_emulator/item_data.py
@@ -1,0 +1,322 @@
+"""
+Parser for the per-item CA mapping tables.
+
+Two source files are loaded by ``CAManager`` in mofclient.c:
+
+* ``CA_Character_Dot.txt``         (parsed by ``CAManager::LoadCADataDot``,
+  mofclient.c:245180) — text columns ``%s %s %s %d %s %d``
+  → ``code  type1  name  intval1  type2  intval2``
+
+* ``CA_Character_illustration.txt`` (parsed by ``CAManager::LoadCADataIllust``,
+  mofclient.c:245394) — text columns ``%s %d %d %s``
+  → ``code  byteval  intval  type``
+
+Each row binds a 5-character item code (e.g. ``H0001``) to:
+  • a fashion *slot type* (HAIR / FACE / COAT / …)
+  • a *layer index* inside that slot's ``.ca`` file
+
+The slot type → integer mapping comes from
+``CAManager::ParsingFashionItemType`` (mofclient.c:245488)::
+
+    HAIR=0  FACE=1  COAT=2  TRIUSERS=3  SHOES=4  HAND=5  CLOCK=6
+    RWEAPON=7  LWEAPON=8  ACC1=9  ACC2=10  ACC3=11  MASKHAIR=12
+    SUIT=13  EMOTICON=14  DUALWEAPON=15
+
+The 16-bit item ID stored in the live game comes from
+``CAManager::ItemtoWORD`` (mofclient.c:246219)::
+
+    ((toupper(letter) + 31) << 11) | atoi(digits)
+
+Public API::
+
+    from item_data import (load_dot_items, load_illust_items,
+                           item_code_to_id, item_id_to_code,
+                           SLOT_NAMES)
+
+    items = load_dot_items("MoFData/CA_Character_Dot.txt")
+    print(items["H0001"])   # ItemCAInfoDot(...)
+    print(item_code_to_id("H0001"))
+"""
+
+import os
+
+
+# ── Constants matching CAManager::ParsingFashionItemType ─────────────────────
+
+SLOT_HAIR        = 0
+SLOT_FACE        = 1
+SLOT_COAT        = 2
+SLOT_TRIUSERS    = 3
+SLOT_SHOES       = 4
+SLOT_HAND        = 5
+SLOT_CLOCK       = 6
+SLOT_RWEAPON     = 7
+SLOT_LWEAPON     = 8
+SLOT_ACC1        = 9
+SLOT_ACC2        = 10
+SLOT_ACC3        = 11
+SLOT_MASKHAIR    = 12
+SLOT_SUIT        = 13
+SLOT_EMOTICON    = 14
+SLOT_DUALWEAPON  = 15
+
+SLOT_NAMES = {
+    SLOT_HAIR:       'HAIR',
+    SLOT_FACE:       'FACE',
+    SLOT_COAT:       'COAT',
+    SLOT_TRIUSERS:   'TRIUSERS',
+    SLOT_SHOES:      'SHOES',
+    SLOT_HAND:       'HAND',
+    SLOT_CLOCK:      'CLOCK',
+    SLOT_RWEAPON:    'RWEAPON',
+    SLOT_LWEAPON:    'LWEAPON',
+    SLOT_ACC1:       'ACC1',
+    SLOT_ACC2:       'ACC2',
+    SLOT_ACC3:       'ACC3',
+    SLOT_MASKHAIR:   'MASKHAIR',
+    SLOT_SUIT:       'SUIT',
+    SLOT_EMOTICON:   'EMOTICON',
+    SLOT_DUALWEAPON: 'DUALWEAPON',
+}
+
+# Reverse: name → slot id (case-insensitive)
+SLOT_BY_NAME = {v.upper(): k for k, v in SLOT_NAMES.items()}
+# Aliases sometimes seen in the data files
+SLOT_BY_NAME['NONE'] = -1
+SLOT_BY_NAME['NULL'] = -1
+
+
+def parse_slot_type(name):
+    """Return the slot id for a slot keyword, or -1 if not recognised.
+
+    Mirrors ``CAManager::ParsingFashionItemType`` (mofclient.c:245488).
+    """
+    if not name:
+        return -1
+    return SLOT_BY_NAME.get(name.upper(), -1)
+
+
+# ── Item code ⇄ 16-bit id (CAManager::ItemtoWORD, mofclient.c:246219) ────────
+
+def item_code_to_id(code):
+    """Convert a 5-character item code (e.g. ``H0001``) to a 16-bit id.
+
+    Returns 0 on failure, matching ``ItemtoWORD``'s convention.
+    """
+    if not code or len(code) != 5:
+        return 0
+    try:
+        upper = (ord(code[0].upper()) + 31) << 11
+        digits = int(code[1:])
+    except (ValueError, IndexError):
+        return 0
+    if digits >= 0x800:
+        return 0
+    return (upper | digits) & 0xFFFF
+
+
+def item_id_to_code(item_id):
+    """Inverse of :func:`item_code_to_id`.
+
+    The forward mapping is ``((toupper(c) + 31) << 11) | digits`` and the
+    result is truncated to 16 bits, so only the low 5 bits of ``c + 31``
+    survive. For ``'A'..'Z'`` (65..90), ``c + 31`` is ``96..121``, whose low
+    5 bits are ``0..25`` — therefore the inverse is simply ``chr(bits + 65)``.
+    """
+    if item_id <= 0:
+        return ''
+    bits = (item_id >> 11) & 0x1F
+    digits = item_id & 0x7FF
+    return '%c%04d' % (chr(bits + ord('A')), digits)
+
+
+# ── Data classes ──────────────────────────────────────────────────────────────
+
+class ItemCAInfoDot:
+    """An entry of CA_Character_Dot.txt (per-item slot bindings).
+
+    Mirrors the 0x78-byte ``ITEMCAINFO_DOT`` allocated in
+    ``CAManager::LoadCADataDot`` (mofclient.c:245209).
+    """
+    __slots__ = ('code', 'item_id', 'name',
+                 'type1', 'layer_index1',
+                 'type2', 'layer_index2')
+
+    def __init__(self, code='', name='',
+                 type1=-1, layer_index1=0,
+                 type2=-1, layer_index2=0):
+        self.code = code
+        self.item_id = item_code_to_id(code)
+        self.name = name
+        self.type1 = type1
+        self.layer_index1 = layer_index1
+        self.type2 = type2
+        self.layer_index2 = layer_index2
+
+    @property
+    def primary_slot_name(self):
+        return SLOT_NAMES.get(self.type1, '?')
+
+    @property
+    def secondary_slot_name(self):
+        return SLOT_NAMES.get(self.type2, '?')
+
+    def __repr__(self):
+        return ('ItemCAInfoDot(%s id=0x%04X "%s" %s/%d + %s/%d)'
+                % (self.code, self.item_id, self.name,
+                   self.primary_slot_name, self.layer_index1,
+                   self.secondary_slot_name, self.layer_index2))
+
+
+class ItemCAInfoIllust:
+    """An entry of CA_Character_illustration.txt.
+
+    Mirrors the 0x0C-byte ``ITEMCAINFO_ILLUST`` allocated in
+    ``CAManager::LoadCADataIllust`` (mofclient.c:245420).
+    """
+    __slots__ = ('code', 'item_id', 'byte_val', 'frame_index', 'type')
+
+    def __init__(self, code='', byte_val=0, frame_index=0, type=-1):
+        self.code = code
+        self.item_id = item_code_to_id(code)
+        self.byte_val = byte_val
+        self.frame_index = frame_index
+        self.type = type
+
+    @property
+    def slot_name(self):
+        return SLOT_NAMES.get(self.type, '?')
+
+    def __repr__(self):
+        return ('ItemCAInfoIllust(%s id=0x%04X %s frame=%d byte=%d)'
+                % (self.code, self.item_id, self.slot_name,
+                   self.frame_index, self.byte_val))
+
+
+# ── Loaders ───────────────────────────────────────────────────────────────────
+
+def _open_text(path):
+    """Open a text file, trying common Korean / Asian encodings."""
+    encodings = ('utf-8-sig', 'cp949', 'cp950', 'big5', 'utf-8', 'latin-1')
+    last_err = None
+    for enc in encodings:
+        try:
+            with open(path, 'r', encoding=enc) as f:
+                return f.read().splitlines(), enc
+        except UnicodeDecodeError as e:
+            last_err = e
+    raise last_err
+
+
+def load_dot_items(path):
+    """Parse ``CA_Character_Dot.txt`` and return ``dict[str, ItemCAInfoDot]``.
+
+    The first line is a header (skipped), then each subsequent line is::
+
+        code  type1  name  intval1  type2  intval2
+
+    Tab- or whitespace-separated; mirrors the ``%s %s %s %d %s %d`` sscanf in
+    ``CAManager::LoadCADataDot`` (mofclient.c:245204).
+    """
+    if not os.path.isfile(path):
+        return {}
+    lines, _enc = _open_text(path)
+    out = {}
+    started = False
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith('//') or line.startswith('#'):
+            continue
+        # Skip the first non-empty/comment line — it is the header.
+        if not started:
+            started = True
+            continue
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        code, type1_name, name, intval1, type2_name, intval2 = parts[:6]
+        try:
+            iv1 = int(intval1)
+            iv2 = int(intval2)
+        except ValueError:
+            continue
+        info = ItemCAInfoDot(
+            code=code,
+            name=name,
+            type1=parse_slot_type(type1_name),
+            layer_index1=iv1,
+            type2=parse_slot_type(type2_name),
+            layer_index2=iv2,
+        )
+        if info.item_id:
+            out[code.upper()] = info
+    return out
+
+
+def load_illust_items(path):
+    """Parse ``CA_Character_illustration.txt`` → ``dict[str, ItemCAInfoIllust]``.
+
+    Each line is ``code byteval intval type`` (``%s %d %d %s``), matching
+    ``CAManager::LoadCADataIllust`` (mofclient.c:245418).
+    """
+    if not os.path.isfile(path):
+        return {}
+    lines, _enc = _open_text(path)
+    out = {}
+    started = False
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith('//') or line.startswith('#'):
+            continue
+        if not started:
+            started = True
+            continue
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        code, byte_val, frame_index, type_name = parts[:4]
+        try:
+            bv = int(byte_val)
+            fi = int(frame_index)
+        except ValueError:
+            continue
+        info = ItemCAInfoIllust(
+            code=code,
+            byte_val=bv,
+            frame_index=fi,
+            type=parse_slot_type(type_name),
+        )
+        if info.item_id:
+            out[code.upper()] = info
+    return out
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Dump CA item-binding tables (DOT/ILLUST).')
+    parser.add_argument('--dot',    help='CA_Character_Dot.txt')
+    parser.add_argument('--illust', help='CA_Character_illustration.txt')
+    parser.add_argument('--filter', help='Only show entries whose code starts with this prefix')
+    args = parser.parse_args()
+
+    if args.dot:
+        items = load_dot_items(args.dot)
+        print('DOT  items:', len(items))
+        for code, info in sorted(items.items()):
+            if args.filter and not code.startswith(args.filter.upper()):
+                continue
+            print(' ', info)
+    if args.illust:
+        items = load_illust_items(args.illust)
+        print('ILLUST items:', len(items))
+        for code, info in sorted(items.items()):
+            if args.filter and not code.startswith(args.filter.upper()):
+                continue
+            print(' ', info)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a complete character emulator for Mabinogi Fantasy (MoF), enabling interactive preview and customization of dot and illustration character sprites with equipment layering.

## Summary
Implements a full pipeline for loading, parsing, and rendering MoF character animation data:
- **GI parser** (`gi_parser.py`): Reverse-engineered binary format parser for texture atlases with RLE decompression and D3D format conversion (A8R8G8B8, DXT1/3/5, etc.)
- **CA parser** (`parse_ca.py`): Animation timeline format supporting keyframe animation and layer composition
- **Character loader** (`ca_loader.py`): High-level loader mirroring the game's `CAManager` that assembles 16 equipment slots + base character
- **Renderer** (`character_renderer.py`): Composite renderer that applies equipment overrides and renders frames to PIL images
- **Item data** (`item_data.py`): Parser for item-to-slot mappings with bidirectional item code ↔ ID conversion
- **Tkinter UI** (`character_emulator.py`): Interactive application with equipment selection, animation playback, and frame stepping

## Key Implementation Details
- **RLE decompression**: Implements byte/word/dword-level run-length decompression matching `Comp.cpp` with 0xB4 marker bytes
- **DXT texture decoding**: Full DXT1/DXT3/DXT5 block decoder with proper alpha interpolation
- **Equipment system**: Mirrors `CCA::LayerPutOn` logic with per-slot layer index offsets (e.g., HAIR paints CCA slots 7 and 19)
- **Animation**: Supports keyframe-based animation with configurable FPS and frame stepping
- **Case-insensitive file lookup**: Linux-friendly path resolution for Windows-centric asset naming
- **Lazy loading**: GI textures and character files loaded on-demand with caching

## UI Features
- Equipment slot selection via comboboxes (16 categories: HAIR, COAT, WEAPONS, etc.)
- Animation playback with pause/resume and frame-by-frame stepping
- Dot/Illust mode toggle
- Item code lookup for quick equipment binding
- Real-time frame counter and animation metadata display

https://claude.ai/code/session_01PJL4kdxrL5Wo1sZS13cJhb