### PR TITLE
Fix effect rendering and sprite drawing in character animation

### DIFF
--- a/inc/Character/CCA.h
+++ b/inc/Character/CCA.h
@@ -4,8 +4,8 @@
 #include <d3dx9.h>
 #include "Character/CATypes.h"
 
-struct CEffectBase;
-class  GameImage;
+class CEffectBase;
+class GameImage;
 
 // =============================================================================
 // CCA  (292 bytes in the original binary)

--- a/src/Character/CAManager.cpp
+++ b/src/Character/CAManager.cpp
@@ -14,6 +14,16 @@
 #include <windows.h>
 
 // ============================================================================
+// Weak statistics counters from the ground-truth binary (data addresses
+// 0x2255AB8 / 0x2255ABC).  LoadCADataDot bumps the allocation counter when
+// it creates a new ITEMCAINFO_DOT and the destructor bumps the deallocation
+// counter for each one it frees.  Exposed as externals so test harnesses can
+// sample them, mirroring the original weak symbols.
+// ============================================================================
+int nAllocCntItemCAInfo   = 0;
+int nDeAllocCntItemCAInfo = 0;
+
+// ============================================================================
 // Helpers for type constructors (match original 0-initialization semantics).
 // ============================================================================
 
@@ -166,6 +176,7 @@ CAManager::~CAManager()
     {
         if (m_pItemCAInfoDot[i])
         {
+            ++nDeAllocCntItemCAInfo;
             delete m_pItemCAInfoDot[i];
             m_pItemCAInfoDot[i] = nullptr;
         }
@@ -205,6 +216,7 @@ FILE* CAManager::LoadCADataDot(char* filename)
         {
             ITEMCAINFO_DOT* pRec = new ITEMCAINFO_DOT();
             m_pItemCAInfoDot[itemID] = pRec;
+            ++nAllocCntItemCAInfo;
             pRec->m_wItemID = itemID;
 
             int typeAResult = ParsingFashionItemType(typeA);

--- a/src/Character/CCA.cpp
+++ b/src/Character/CCA.cpp
@@ -1,5 +1,6 @@
 #include "Character/CCA.h"
 #include "Character/CAManager.h"
+#include "Effect/CEffectBase.h"
 #include "Image/cltImageManager.h"
 #include "Image/CDeviceResetManager.h"
 #include "Image/CDeviceManager.h"
@@ -503,17 +504,17 @@ bool CCA::Draw(int viewport)
 
     bool renderStateTouched = false;
 
-    // Effects rendered before the character body.
+    // Effects rendered before the character body.  Ground truth dispatches
+    // through vtable slot +12 on the first CEffectBase* held at m_pEffectBefore,
+    // which corresponds to CEffectBase::Draw() in our class layout
+    // (dtor/FrameProcess/Process/Draw => slots 0/4/8/12 in 32-bit).  Call the
+    // virtual directly so derived effects render their pre-body pass.
     if (m_pEffectBefore && !m_nTransportActive)
     {
         CEffectBase* pEff = *m_pEffectBefore;
         if (pEff)
         {
-            // Original: (*(void (__thiscall **)(int))(*(_DWORD *)v6 + 12))(v6);
-            // We cannot dispatch through an unknown vtable slot here �X instead
-            // treat the effect as opaque and simply mark the renderstate as
-            // touched so it gets reset below.
-            (void)pEff;
+            pEff->Draw();
             renderStateTouched = true;
         }
         if (renderStateTouched)
@@ -526,28 +527,25 @@ bool CCA::Draw(int viewport)
     ID3DXSprite* pSprite = reinterpret_cast<ID3DXSprite*>(m_pSprite);
     if (pSprite) pSprite->Begin(static_cast<DWORD>(viewport));
 
+    // Ground truth (D3DX8) path: for every image in the draw list, compute
+    // scale+tint+position then dispatch the sprite's Draw vtable entry with
+    // (tex, srcRect, scale, center, rot, pos, color).  Our port is D3DX9 and
+    // GameImage owns its own vertex buffer pipeline, so the per-image vertex
+    // state (position, tint, mirror flip) is already set up in Process(); we
+    // only need to invoke GameImage::Draw() here to issue the DrawPrimitive.
     size_t count = CCA_VectorSize(this);
     for (size_t i = 0; i < count; ++i)
     {
         GameImage* pGI = m_pVecBegin[i];
         if (!pGI || !pGI->m_pGIData) continue;
-        // Compute per-GameImage tint & position then dispatch to sprite->Draw.
-        float scale[2]  = { 1.0f, 1.0f };
-        float position[2] = { pGI->m_fPosX, pGI->m_fPosY };
-        if (static_cast<int>(i) == m_nTransportMask)
-        {
-            // override tint: (original uses 1023410175 = 0x3F000000 = 0.5f)
-        }
-        if (m_bMirrored) scale[0] = -1.0f;
-        RECT rc; pGI->GetBlockRect(&rc);
-        // The sprite drawing call is opaque in the decompilation; invoke
-        // GameImage::Draw() which already wraps the D3DX sprite pipeline.
         pGI->Draw();
     }
 
     if (pSprite) pSprite->End();
 
-    // Effects rendered after the character body.
+    // Effects rendered after the character body.  Ground truth iterates
+    // m_pEffectAfter over 9 slots (for i = 0; i < 36; i += 4) and dispatches
+    // vtable slot +12 on each non-null entry; that is CEffectBase::Draw().
     if (m_pEffectAfter)
     {
         for (int i = 0; i < 9; ++i)
@@ -555,7 +553,7 @@ bool CCA::Draw(int viewport)
             CEffectBase* pEff = m_pEffectAfter[i];
             if (pEff)
             {
-                (void)pEff;
+                pEff->Draw();
                 renderStateTouched = true;
             }
         }

--- a/src/Character/CCAClone.cpp
+++ b/src/Character/CCAClone.cpp
@@ -299,21 +299,18 @@ void CCAClone::Draw()
     ID3DXSprite* pSprite = reinterpret_cast<ID3DXSprite*>(m_pSprite);
     pSprite->Begin(0);
 
+    // Ground truth (D3DX8) issues the sprite's Draw vtable entry with
+    // (tex, srcRect, scale, center, rot, pos, color) and then calls
+    // GameImage::SetDefaultTextureColor after each image.  In our D3DX9 port
+    // the per-image transform / tint / mirror flip is already baked into the
+    // GameImage vertex buffer by Process(), so we just invoke GameImage::Draw
+    // to issue the DrawPrimitive and restore the default tint afterwards.
     size_t count = CCAClone_VectorSize(this);
     for (size_t i = 0; i < count; ++i)
     {
         GameImage* pGI = m_pVecBegin[i];
         if (!pGI || !pGI->m_pGIData) continue;
-
-        // Match the original: read+restore the GameImage overwrite color so
-        // the final tint respects our m_bMirrored horizontal flip.
-        float oc[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
-        pGI->GetOverWriteTextureColor(oc);
-        (void)ClampFloatToByte(oc[0]);  // (values folded into the tint below)
-
-        RECT rc; pGI->GetBlockRect(&rc);
         pGI->Draw();
-
         pGI->SetDefaultTextureColor();
     }
 

--- a/src/Character/CCAillust.cpp
+++ b/src/Character/CCAillust.cpp
@@ -238,13 +238,13 @@ void CCAillust::Draw(int viewport)
         RECT rc;
         pGI->GetBlockRect(&rc);
 
-        // The decompile dispatches through a wrapper that takes (texture, rect,
-        // matrix, color).  ID3DXSprite::Draw's signature is (tex, rect, center,
-        // pos, color) — feed the matrix translation as the position vector to
-        // preserve behaviour.
-        D3DXVECTOR3 pos(pGI->m_fPosX, pGI->m_fPosY, 0.0f);
+        // Ground truth calls ID3DXSprite::DrawTransform(tex, rect, matrix,
+        // color) — a D3DX8 API.  In D3DX9 the equivalent is
+        //   SetTransform(matrix); Draw(tex, rect, nullptr, nullptr, color);
+        // Passing both the transform AND a position vector would double the
+        // translation, so feed the position only through SetTransform here.
         pSprite->SetTransform(&trans);
-        pSprite->Draw(pTexture, &rc, nullptr, &pos, color);
+        pSprite->Draw(pTexture, &rc, nullptr, nullptr, color);
     }
 
     pSprite->End();


### PR DESCRIPTION
## Summary
This PR fixes several rendering issues in the character animation system by properly invoking virtual methods on effect objects and correcting sprite transformation handling. The changes align the codebase with the ground-truth binary behavior and improve code clarity with detailed comments explaining the D3DX8-to-D3DX9 API migration.

## Key Changes

- **Effect rendering (CCA.cpp)**: Replace placeholder code with proper virtual method calls to `CEffectBase::Draw()` for both pre-body and post-body effects. Added detailed comments explaining the vtable dispatch mechanism and why direct virtual calls are now safe.

- **Sprite drawing simplification (CCA.cpp, CCAClone.cpp)**: Remove redundant per-image transform calculations and color clamping logic. The vertex buffer pipeline in `GameImage` already handles position, tint, and mirror flip during `Process()`, so only `GameImage::Draw()` needs to be invoked.

- **Sprite transform fix (CCAillust.cpp)**: Correct `ID3DXSprite::Draw()` call to avoid double-translation. The D3DX8 `DrawTransform()` API is emulated in D3DX9 by calling `SetTransform()` followed by `Draw()` with a null position vector, not both the transform and position.

- **Statistics counters (CAManager.cpp)**: Add weak symbol counters (`nAllocCntItemCAInfo` and `nDeAllocCntItemCAInfo`) to track `ITEMCAINFO_DOT` allocations and deallocations, mirroring the original binary for test harness compatibility.

- **Forward declaration cleanup (CCA.h)**: Change `struct CEffectBase` to `class CEffectBase` for consistency with the actual class definition.

## Implementation Details

All changes include comprehensive comments documenting the ground-truth behavior, the D3DX8→D3DX9 API migration rationale, and the current implementation strategy. This improves maintainability and clarifies why certain patterns are used.

https://claude.ai/code/session_01B5aQA5YDyCSRonXMSbMH9d