### PR TITLE
Align character animation image loading with game client

### DIFF
--- a/src/Character/CAManager.cpp
+++ b/src/Character/CAManager.cpp
@@ -622,25 +622,36 @@ void CAManager::LoadDefinImage()
     {
         const int hairIdx = m_DefineInfoDot[i].m_nLayerIndex;
         LAYERINFO* pLayer0 = GetDotLayer(0, hairIdx);
-        if (!pLayer0 || !pLayer0->m_pFrames) continue;
+        if (!pLayer0 || !pLayer0->m_pFrames)
+        {
+            // GT: CLog::Log("LoadDefinImage GetDotLayer(ITEM_KIND_HAIR) return NULL");
+            ::OutputDebugStringA("LoadDefinImage GetDotLayer(ITEM_KIND_HAIR) return NULL\n");
+            continue;
+        }
 
         auto* pDraw = static_cast<CA_DRAWENTRY*>(pLayer0->m_pFrames[0].m_pEntries1);
         if (pDraw) pIM->GetGameImage(0, pDraw->m_dwImageID, 0, 0);
 
         LAYERINFO* pLayer1 = GetDotLayer(0, hairIdx + 1);
-        if (pLayer1 && pLayer1->m_pFrames)
+        if (!pLayer1 || !pLayer1->m_pFrames)
         {
-            pDraw = static_cast<CA_DRAWENTRY*>(pLayer1->m_pFrames[0].m_pEntries1);
-            if (pDraw) pIM->GetGameImage(0, pDraw->m_dwImageID, 0, 0);
+            // GT: CLog::Log("LoadDefinImage GetDotLayer(ITEM_KIND_HAIR + 1) return NULL");
+            ::OutputDebugStringA("LoadDefinImage GetDotLayer(ITEM_KIND_HAIR + 1) return NULL\n");
+            continue;
         }
+        pDraw = static_cast<CA_DRAWENTRY*>(pLayer1->m_pFrames[0].m_pEntries1);
+        if (pDraw) pIM->GetGameImage(0, pDraw->m_dwImageID, 0, 0);
 
         const int faceIdx = m_DefineInfoDot[30 + i].m_nLayerIndex;
         LAYERINFO* pLayerFace = GetDotLayer(1, faceIdx);
-        if (pLayerFace && pLayerFace->m_pFrames)
+        if (!pLayerFace || !pLayerFace->m_pFrames)
         {
-            pDraw = static_cast<CA_DRAWENTRY*>(pLayerFace->m_pFrames[0].m_pEntries1);
-            if (pDraw) pIM->GetGameImage(0, pDraw->m_dwImageID, 0, 0);
+            // GT: CLog::Log("LoadDefinImage GetDotLayer(ITEM_KIND_FACE) return NULL");
+            ::OutputDebugStringA("LoadDefinImage GetDotLayer(ITEM_KIND_FACE) return NULL\n");
+            continue;
         }
+        pDraw = static_cast<CA_DRAWENTRY*>(pLayerFace->m_pFrames[0].m_pEntries1);
+        if (pDraw) pIM->GetGameImage(0, pDraw->m_dwImageID, 0, 0);
     }
 
     // The ground truth finishes with 8 specific prewarm calls that walk

--- a/src/Character/CCAClone.cpp
+++ b/src/Character/CCAClone.cpp
@@ -191,25 +191,38 @@ void CCAClone::Process()
 
             cltImageManager* pIM = cltImageManager::GetInstance();
             GameImage* pGI = nullptr;
+            bool bNeedFallback = false;
             if (slot == 11)
             {
+                // Slot 11 (dualweapon back): validate only that the GIData
+                // node exists; the texture may legitimately be lazy-loaded.
                 pGI = pIM ? pIM->GetGameImage(0, pEntry->m_dwImageID, 0, 0) : nullptr;
+                bNeedFallback = (!pGI || !pGI->m_pGIData);
             }
             else
             {
                 pGI = pIM ? pIM->GetGameImage(0, pEntry->m_dwImageID, 0, 1) : nullptr;
+                // GT (mofclient.c 243016-243019) additionally checks
+                // m_pGIData->m_Resource.m_pTexture here: if the texture has
+                // not been uploaded to D3D yet, treat the fetch as failed
+                // and drop into the fallback recovery path.
+                bNeedFallback = (!pGI || !pGI->m_pGIData ||
+                                 !pGI->m_pGIData->m_Resource.m_pTexture);
             }
 
             // Fallback recovery (byte_5280FC cases).  The weak LUT is all zero,
             // so only case 0 (hair re-resolve) is reachable in the original —
             // all other cases fall through to LABEL_106 (skip).
-            if (!pGI || !pGI->m_pGIData)
+            if (bNeedFallback)
             {
+                // GT resets a2/v71 = 0 at LABEL_21 before attempting recovery,
+                // so a failed fallback drops this entry entirely instead of
+                // keeping the (potentially texture-less) original GameImage.
+                pGI = nullptr;
                 int hairIdx = m_nHairIndex;
                 int faceIdx = m_nFaceIndex;
-                if (hairIdx == -1 || faceIdx == -1) { pGI = nullptr; }
-                else if (m_ucSex > 1 || slot < 1 || slot > 19) { pGI = nullptr; }
-                else
+                if (hairIdx != -1 && faceIdx != -1 &&
+                    m_ucSex <= 1 && slot >= 1 && slot <= 19)
                 {
                     int fallbackCase = byte_5280FC[slot - 1];
                     if (fallbackCase == 0)
@@ -223,9 +236,12 @@ void CCAClone::Process()
                             if (e < pFR->m_nCount1)
                             {
                                 CA_DRAWENTRY* pEnt = static_cast<CA_DRAWENTRY*>(pFR->m_pEntries1) + e;
-                                pGI = pIM ? pIM->GetGameImage(0, pEnt->m_dwImageID, 0, 0) : nullptr;
-                                pEntry = pEnt;
-                                if (!pGI || !pGI->m_pGIData) pGI = nullptr;
+                                GameImage* pRec = pIM ? pIM->GetGameImage(0, pEnt->m_dwImageID, 0, 0) : nullptr;
+                                if (pRec && pRec->m_pGIData)
+                                {
+                                    pGI = pRec;
+                                    pEntry = pEnt;
+                                }
                             }
                         }
                     }

--- a/src/Character/CCANormal.cpp
+++ b/src/Character/CCANormal.cpp
@@ -3,6 +3,7 @@
 #include "Image/cltImageManager.h"
 #include "Image/GameImage.h"
 #include "FileSystem/CMOFPacking.h"
+#include "UI/CMessageBoxManager.h"
 #include "global.h"
 
 #include <cstring>
@@ -305,7 +306,8 @@ void CCANormal::LoadCAInPack(char* filename)
     {
         char msg[256];
         std::snprintf(msg, sizeof(msg), "%s didn't find Character Animation File.", filename);
-        ::MessageBoxA(nullptr, msg, nullptr, 0);
+        // GT: CMessageBoxManager::AddOK(g_pMsgBoxMgr, Buffer, 0, 0, 0, -1);
+        if (g_pMsgBoxMgr) g_pMsgBoxMgr->AddOK(msg, 0, 0, 0, -1);
         return;
     }
 
@@ -317,7 +319,8 @@ void CCANormal::LoadCAInPack(char* filename)
     {
         char msg[256];
         std::snprintf(msg, sizeof(msg), "%s didn't find Character Animation File.", filename);
-        ::MessageBoxA(nullptr, msg, nullptr, 0);
+        // GT: CMessageBoxManager::AddOK(g_pMsgBoxMgr, Buffer, 0, 0, 0, -1);
+        if (g_pMsgBoxMgr) g_pMsgBoxMgr->AddOK(msg, 0, 0, 0, -1);
         return;
     }
 
@@ -335,7 +338,8 @@ void CCANormal::LoadCA(const char* filename)
     {
         char msg[256];
         std::snprintf(msg, sizeof(msg), "%s didn't find Character Animation File.", filename);
-        ::MessageBoxA(nullptr, msg, nullptr, 0);
+        // GT: CMessageBoxManager::AddOK(g_pMsgBoxMgr, Buffer, 0, 0, 0, -1);
+        if (g_pMsgBoxMgr) g_pMsgBoxMgr->AddOK(msg, 0, 0, 0, -1);
         return;
     }
     FileSrc cursor{ fp };


### PR DESCRIPTION
## Summary
This PR aligns the character animation image loading logic with the original game client (GT) implementation, improving texture validation, error handling, and fallback recovery paths.

## Key Changes

- **CCAClone.cpp**: Enhanced texture validation for slot 11 (dualweapon back) and other slots
  - Added explicit `bNeedFallback` flag to distinguish between lazy-loaded textures (slot 11) and missing D3D textures (other slots)
  - Implemented texture upload validation by checking `m_pGIData->m_Resource.m_pTexture` for non-slot-11 entries
  - Refactored fallback recovery logic to reset `pGI` to nullptr before attempting recovery, matching GT behavior
  - Improved fallback entry validation to only update `pGI` and `pEntry` when recovery succeeds

- **CAManager.cpp**: Standardized error handling in `LoadDefinImage()`
  - Inverted null-check conditions for hair, hair+1, and face layer validation
  - Added debug output messages for missing layer data (matching GT's logging approach)
  - Simplified control flow by using early `continue` statements instead of nested conditionals

- **CCANormal.cpp**: Replaced direct MessageBox calls with message manager
  - Added include for `CMessageBoxManager`
  - Replaced three `::MessageBoxA()` calls with `g_pMsgBoxMgr->AddOK()` in `LoadCAInPack()` and `LoadCA()` methods
  - Added null-safety checks for the message box manager

## Notable Implementation Details

- The texture validation now distinguishes between lazy-loaded textures (which are valid for slot 11) and textures that haven't been uploaded to D3D yet (which require fallback recovery)
- Fallback recovery now properly resets the GameImage pointer before attempting to find a replacement, preventing use of texture-less images
- Error messages now route through the UI message manager instead of blocking system MessageBox calls, improving integration with the game's UI system

https://claude.ai/code/session_01FL11f55xgpBwA5bGAePyFi