### PR TITLE
Fix mini-game score validation logic for Exorcist 2 and Bow 2

### DIFF
--- a/src/MiniGame/cltValidMiniGameScore.cpp
+++ b/src/MiniGame/cltValidMiniGameScore.cpp
@@ -20,7 +20,9 @@ int cltValidMiniGameScore::IsValidScore(std::uint8_t lessonType, std::uint32_t s
             break;
         case 0x15u: // cltMini_Exorcist_2（神學 2）
         case 0x1Eu: // cltMini_Bow_2（弓箭 2）
-            if (score >= 0x0Au) return 0;
+            // mofclient.c 0x5A0040: `if ( a2 >= 0xA ) goto LABEL_16(=valid)`
+            // 亦即這兩種小遊戲要求分數至少為 10 才算合法，<10 視為無效。
+            if (score < 0x0Au) return 0;
             break;
         case 0x1Fu: // cltMini_Magic（魔法 1）
             if (score > 0x96u) return 0;


### PR DESCRIPTION
## Summary
Fixed incorrect score validation logic for two mini-games (Exorcist 2 and Bow 2) that was rejecting valid scores instead of invalid ones.

## Key Changes
- **Corrected validation condition**: Changed `if (score >= 0x0Au)` to `if (score < 0x0Au)` for lesson types 0x15 and 0x1E
- **Added documentation**: Included comments referencing the original mofclient.c implementation (0x5A0040) and clarifying that scores must be at least 10 to be considered valid
- **Logic fix**: The validation now correctly rejects scores below 10 (invalid) instead of rejecting scores of 10 or above (which were valid)

## Implementation Details
The original condition had inverted logic - it was returning 0 (invalid) when the score was valid (>= 10). The fix aligns the validation with the original client implementation where scores below 10 are considered invalid for these two mini-game types.

https://claude.ai/code/session_012C8hs2UAQXF7z9SmJ4jtzD