### PR TITLE
Implement GetMyCharName shim and clarify lesson system usage

### DIFF
--- a/inc/Logic/cltMyCharData.h
+++ b/inc/Logic/cltMyCharData.h
@@ -31,6 +31,12 @@ public:
     static void SetMapID(cltMyCharData* self, unsigned short mapKind);
 
     static void SetMyCharName(cltMyCharData* self, const char* name);
+
+    // mofclient.c 0x518610：此函式在原始程式碼實際上只是 `return this;`
+    // 原因是 cltMyCharData 的前幾個 byte 即為以 NUL 結尾的角色名稱字串，
+    // 呼叫端會把回傳值直接餵給 _wsprintfA 的 "%s"。這裡提供相同語意的 shim，
+    // 讓 minigame 等呼叫端能對齊 GT 的呼叫寫法。
+    static cltMyCharData* GetMyCharName(cltMyCharData* self);
 };
 
 extern cltMyCharData g_clMyCharData;

--- a/src/Logic/cltMyCharData.cpp
+++ b/src/Logic/cltMyCharData.cpp
@@ -45,3 +45,12 @@ void cltMyCharData::SetMapID(cltMyCharData* /*self*/, unsigned short /*mapKind*/
 void cltMyCharData::SetMyCharName(cltMyCharData* /*self*/, const char* /*name*/) {
     // Stub: real implementation stores the character name.
 }
+
+cltMyCharData* cltMyCharData::GetMyCharName(cltMyCharData* self) {
+    // Ground truth 0x518610：
+    //   cltMyCharData *__thiscall cltMyCharData::GetMyCharName(cltMyCharData *this)
+    //   { return this; }
+    // 呼叫端 (_wsprintfA(..., fmt, GetMyCharName(...), ...)) 會把回傳值當作
+    // 指向角色名稱字元陣列（位於 cltMyCharData 起始位址）的 char*。
+    return self;
+}

--- a/src/MiniGame/cltMoF_BaseMiniGame.cpp
+++ b/src/MiniGame/cltMoF_BaseMiniGame.cpp
@@ -18,8 +18,13 @@
 #include "System/cltLessonSystem.h"
 #include "Info/cltItemKindInfo.h"
 
-// mofclient.c 取用 g_clLessonSystem 的等價全域（原始碼經由
-// cltMyCharData 物件的 +6568 偏移抓到 lesson system 實例）。
+// 原始碼 (mofclient.c 0x5BE910/0x5BE920) 取用的 lesson system 位於
+// cltMyCharData 物件的 +6568 偏移處：
+//     cltLessonSystem::GetTraningItemKind((char*)m_pclMyChatData + 6568)
+// 本還原專案中 cltMyCharData 為不含內嵌子系統的精簡 stub，因此將所有
+// lesson system 操作統一放到獨立全域 g_clLessonSystem。整個專案
+// (cltMini_Sword.cpp / cltMini_Sword_2.cpp 等) 都走這個全域，所以
+// 語意上等同於 GT — 不存在「兩份 lesson system 不同步」的風險。
 extern cltLessonSystem g_clLessonSystem;
 
 // --- 靜態成員定義 ---
@@ -202,19 +207,26 @@ void cltMoF_BaseMiniGame::SetMyRanking(int rank)
 {
     int textId;
     int rankValue;
+    cltMyCharData* name;
+    // mofclient.c 0x5BE370：兩個分支都在 if/else 內呼叫 GetMyCharName，
+    // 結果會跟 rankValue、textId 一起當作 _wsprintfA 的可變參數。
     if (rank == -1)
     {
         rankValue = 300;
+        name = cltMyCharData::GetMyCharName(m_pclMyChatData);
         textId = 3338;
     }
     else
     {
         rankValue = rank + 1;
+        name = cltMyCharData::GetMyCharName(m_pclMyChatData);
         textId = 3339;
     }
-    // mofclient.c：呼叫 GetMyCharName 取得角色名稱指標作為 wsprintfA 的 %s 參數。
-    cltMyCharData* name = m_pclMyChatData; // GetMyCharName 在原始版本中 return this；
     const char* fmt = m_pDCTTextManager->GetText(textId);
+    // GT：_wsprintfA((LPSTR)this + 421, fmt, v5, v6)
+    //   v5 = GetMyCharName(m_pclMyChatData) 回傳指標 → 在 cltMyCharData 起點
+    //        放著 NUL 結尾的角色名稱，被 %s 解讀為 C-string。
+    //   v6 = rankValue。
     wsprintfA(m_myRankingText, fmt, reinterpret_cast<const char*>(name), rankValue);
 }
 


### PR DESCRIPTION
## Summary
This PR adds the `GetMyCharName()` method to `cltMyCharData` and improves code documentation to better align with the original mofclient.c implementation. The changes clarify how character names are accessed and how the lesson system is managed in the minigame subsystem.

## Key Changes

- **Added `GetMyCharName()` method** to `cltMyCharData` class
  - Implements a shim that returns `this` pointer, matching the original ground truth behavior (0x518610)
  - Character name is stored at the beginning of the `cltMyCharData` object as a NUL-terminated string
  - Allows callers to pass the returned pointer directly to `_wsprintfA` with `%s` format specifier

- **Refactored `SetMyRanking()` in `cltMoF_BaseMiniGame`**
  - Moved `GetMyCharName()` calls into both branches of the if/else statement to match original control flow (0x5BE370)
  - Added detailed comments explaining how the character name pointer is used as a format argument
  - Improved code clarity with explicit variable declaration and GT reference comments

- **Enhanced documentation**
  - Expanded comments in `cltMoF_BaseMiniGame.cpp` explaining the lesson system architecture
  - Clarified that `g_clLessonSystem` is a global singleton used consistently across all minigame implementations
  - Added ground truth (GT) references with original mofclient.c offsets for traceability
  - Documented the rationale for using a stub `cltMyCharData` without embedded subsystems

## Implementation Details

The `GetMyCharName()` method is a semantic shim that preserves the original behavior where the method simply returns the `this` pointer. This works because the character name string is stored at offset 0 of the `cltMyCharData` object, making the object pointer itself a valid `char*` to the name string.

https://claude.ai/code/session_01Fd3FTDAxcT6Nu2zKMgucVT