### PR TITLE
Refactor sword minigame drawing and state management

### DIFF
--- a/inc/MiniGame/Mini_Timer.h
+++ b/inc/MiniGame/Mini_Timer.h
@@ -10,7 +10,7 @@ public:
     void         InitTimer(int secondStep);
     long long    GetCurrentSecond();
     int          GetCurrentSecondDelta();
-    float        GetCurrentFrameTime();
+    double       GetCurrentFrameTime();
 
 private:
     unsigned int m_dwStartTick;   // +0  : 起始 tick

--- a/inc/MiniGame/cltMini_Sword.h
+++ b/inc/MiniGame/cltMini_Sword.h
@@ -144,4 +144,23 @@ public:
     uint32_t   m_serverValid;             // dword 141
     uint32_t   m_serverTimeMs;            // dword 146
     uint32_t   m_exitTick;                // dword 150
+
+    // mofclient.c：PrepareDrawing 取得的背景圖 pointer
+    //   *((_DWORD *)this + 2)：以獨立欄位存放，避免透過 cltMoF_BaseMiniGame 的
+    //   其他成員意外覆寫。Draw 一開始會直接 Draw(m_pBgImage)。
+    GameImage* m_pBgImage;
+
+    // mofclient.c：*((_BYTE *)this + 3966) — 每次 PrepareDrawing 都 +=6 並
+    // 寫入 target FX slot 的 alpha，模擬「緩慢閃爍」的動畫狀態機。
+    uint8_t    m_targetAlphaState;
+
+    // mofclient.c：bytes 604-609 — 6 個 priority 用途的 slot 索引（在 Init 設為
+    // 19/20/21/32/33/34，整個 cltMini_Sword 生命週期不再變動）。這些值被
+    // Draw 使用於首個 loop 的結束界線 (byte606=33) 以及四個 priority slot。
+    uint8_t    m_drawSlot604;             // byte 604 = 19 (ranking base slot)
+    uint8_t    m_drawSlot605;             // byte 605 = 32 (priority slot A)
+    uint8_t    m_drawSlot606;             // byte 606 = 33 (priority slot B / loop bound)
+    uint8_t    m_drawSlot607;             // byte 607 = 34 (priority slot C)
+    uint8_t    m_drawSlot608;             // byte 608 = 20 (ranking prev slot)
+    uint8_t    m_drawSlot609;             // byte 609 = 21 (ranking next slot)
 };

--- a/src/MiniGame/AccuracyBar.cpp
+++ b/src/MiniGame/AccuracyBar.cpp
@@ -47,7 +47,7 @@ void AccuracyBar::InitAccuracyBar(int degree, float x, float y)
     //  1094538581 = 12.30f
     //  1092765989 = 10.95f
     //
-    // degree=0: r=0→15, r=1→12.30, r=2→(no set)
+    // degree=0: r=0→15, r=1→12.30, r=2→10.95 (case 0 fall-through LABEL_19)
     // degree=1: r=0→15, r=1→12.30, r=2→10.95
     // degree=2: r=0→15, r=1→12.30, r=2→10.95
     auto f = [](unsigned int bits) -> float {
@@ -58,6 +58,7 @@ void AccuracyBar::InitAccuracyBar(int degree, float x, float y)
         case 0:
             if (r == 0) m_speed = f(1097020211u);
             else if (r == 1) m_speed = f(1094538581u);
+            else if (r == 2) m_speed = f(1092765989u);
             break;
         case 1:
             if (r == 0) m_speed = f(1097020211u);
@@ -228,7 +229,9 @@ bool AccuracyBar::Process(float dt)
 
 void AccuracyBar::Render()
 {
-    if (m_running && m_pCursor && m_pHighlight)
+    // mofclient.c：只在 running && cursor 存在時直接 Draw(highlight)，
+    // 不額外檢查 highlight 指標是否非 null。
+    if (m_running && m_pCursor)
         m_pHighlight->Draw();
     if (m_pBar)
         m_pBar->Draw();

--- a/src/MiniGame/Mini_Timer.cpp
+++ b/src/MiniGame/Mini_Timer.cpp
@@ -42,8 +42,10 @@ int Mini_Timer::GetCurrentSecondDelta()
     return 1;
 }
 
-float Mini_Timer::GetCurrentFrameTime()
+double Mini_Timer::GetCurrentFrameTime()
 {
+    // mofclient.c：函式簽章回傳 double，內部 m_fFrameSecond 為 float。
+    // 以 float 儲存後再以 double 傳回（將 float 擴展為 double）。
     unsigned int now  = timeGetTime();
     unsigned int prev = m_dwPrevTick;
     m_dwCurTick  = now;

--- a/src/MiniGame/cltMini_Sword.cpp
+++ b/src/MiniGame/cltMini_Sword.cpp
@@ -178,6 +178,14 @@ cltMini_Sword::cltMini_Sword()
     , m_serverValid(0)
     , m_serverTimeMs(0)
     , m_exitTick(0)
+    , m_pBgImage(nullptr)
+    , m_targetAlphaState(0)
+    , m_drawSlot604(19)
+    , m_drawSlot605(32)
+    , m_drawSlot606(33)
+    , m_drawSlot607(34)
+    , m_drawSlot608(20)
+    , m_drawSlot609(21)
 {
     g_cGameSwordState = 0;
 
@@ -243,6 +251,15 @@ void cltMini_Sword::InitMiniGameImage()
     m_slotMissFX      = 26;
     m_slotTargetFX    = 31;
     m_bgResID         = 0x20000023u;
+
+    // mofclient.c：bytes 604-609 — Draw 使用的 6 個 priority 用途 slot 索引
+    //   (Init 設為 19/20/21/32/33/34，整個 cltMini_Sword 生命週期不再變動)
+    m_drawSlot604 = 19;
+    m_drawSlot608 = 20;
+    m_drawSlot609 = 21;
+    m_drawSlot605 = 32;
+    m_drawSlot606 = 33;
+    m_drawSlot607 = 34;
 
     // 3) 13 個按鈕
     //   對齊 mofclient.c 對每個按鈕的 CreateBtn 呼叫 —— 僅以本專案的 API 重排參數。
@@ -453,7 +470,9 @@ void cltMini_Sword::PrepareDrawing()
     cltImageManager* pMgr = m_pclImageMgr;
 
     // 半透明底色 (m_bgResID)
+    // mofclient.c：取得後存入 *((_DWORD *)this + 2)，Draw 會直接 Draw(m_pBgImage)。
     GameImage* pBg = pMgr->GetGameImage(9u, m_bgResID, 0, 1);
+    m_pBgImage = pBg;
     if (pBg)
     {
         pBg->SetBlockID(0);
@@ -504,8 +523,11 @@ void cltMini_Sword::PrepareDrawing()
     }
 
     // Target frame 閃爍
+    // mofclient.c：使用 *((_BYTE *)this + 3966) — 獨立的 byte 狀態，每幀 +=6
+    // 後直接當 alpha 寫入 target FX slot；由於是 byte 運算，會自動 wrap 0..255。
     {
-        unsigned char a = static_cast<unsigned char>(0x9A + dwFrameCnt); // 模擬 +=6 的變化
+        m_targetAlphaState = static_cast<uint8_t>(m_targetAlphaState + 6);
+        uint8_t a = m_targetAlphaState;
         if (m_slots[m_slotTargetFX].active)
         {
             GameImage* p = m_slots[m_slotTargetFX].pImage;
@@ -533,12 +555,22 @@ void cltMini_Sword::PrepareDrawing()
 // =========================================================================
 void cltMini_Sword::Draw()
 {
-    // 40 slot 內可見的兩組：先畫 slot 22~39，再畫 slot 0~21
-    for (int i = m_slots[33].active ? 23 : 22; i < 40; ++i)
+    // mofclient.c：Draw 第一步先畫半透明底圖 (PrepareDrawing 取的那張)
+    if (m_pBgImage)
+        m_pBgImage->Draw();
+
+    // mofclient.c：若 byte606 > 22 才會進 22..(byte606-1) 的迴圈；
+    // byte606 在 Init 中固定為 33，所以實際上畫 slot 22..32。
+    if (m_drawSlot606 > 22u)
     {
-        if (m_slots[i].active && m_slots[i].pImage)
-            m_slots[i].pImage->Draw();
+        for (int i = 22; i < static_cast<int>(m_drawSlot606); ++i)
+        {
+            if (m_slots[i].active && m_slots[i].pImage)
+                m_slots[i].pImage->Draw();
+        }
     }
+
+    // 固定再畫前 22 格（slot 0..21）。
     for (int i = 0; i < 22; ++i)
     {
         if (m_slots[i].active && m_slots[i].pImage)
@@ -558,15 +590,16 @@ void cltMini_Sword::Draw()
 
     m_botBlackBox.Draw();
 
-    // 單獨繪製幾個高優先級的 slot
+    // mofclient.c：四個 priority slot — 順序為 byte605, byte604, byte606, byte607
+    // （對應 slot 32 / 19 / 33 / 34）。
     auto drawSlot = [&](uint8_t idx) {
         if (m_slots[idx].active && m_slots[idx].pImage)
             m_slots[idx].pImage->Draw();
     };
-    drawSlot(m_slotPointFrame);
-    drawSlot(m_slotBtnFrame);
-    drawSlot(m_slotHitFX);
-    drawSlot(m_slotMissFX);
+    drawSlot(m_drawSlot605);
+    drawSlot(m_drawSlot604);
+    drawSlot(m_drawSlot606);
+    drawSlot(m_drawSlot607);
 
     for (int i = 0; i < kButtonCount; ++i)
         m_buttons[i].Draw();

--- a/src/MiniGame/cltMini_Sword_2.cpp
+++ b/src/MiniGame/cltMini_Sword_2.cpp
@@ -643,7 +643,9 @@ void cltMini_Sword_2::SetGameDegree(std::uint8_t degree)
     m_slots[m_uiSelectDegree].active = 0;
 
     // Ready 倒數 3 秒 + 啟動 timer
-    InitMiniGameTime(0, 3u);
+    // mofclient.c：第一參數為 *((_DWORD *)this + 6)，即剛設定好的
+    // m_difficultyBaseScore (Easy=12, Normal=20, Hard=27)。
+    InitMiniGameTime(static_cast<unsigned int>(m_difficultyBaseScore), 3u);
     m_dword149 = 0;
     unsigned int rt = GetReadyTime();
     m_dword149 = g_clTimerManager.CreateTimer(


### PR DESCRIPTION
## Summary
This PR refactors the sword minigame (`cltMini_Sword`) to align with the original mofclient.c implementation by introducing explicit state fields for drawing slots, background image management, and target alpha animation. Additionally, fixes are applied to related minigame components for correctness.

## Key Changes

### cltMini_Sword Drawing & State Management
- **Added new member fields** to track drawing state:
  - `m_pBgImage`: Stores background image pointer for direct drawing in `Draw()`
  - `m_targetAlphaState`: Maintains byte-based alpha state that increments by 6 each frame for target frame blinking animation
  - `m_drawSlot604-609`: Six explicit slot indices (19/20/21/32/33/34) for priority-based drawing order

- **Refactored `Draw()` method**:
  - Now draws background image first via `m_pBgImage->Draw()`
  - Replaced hardcoded slot 33 check with configurable `m_drawSlot606` boundary
  - Changed priority slot drawing from named slots (`m_slotPointFrame`, `m_slotBtnFrame`, etc.) to indexed slots (`m_drawSlot605`, `m_drawSlot604`, `m_drawSlot606`, `m_drawSlot607`)
  - Improved code clarity with explicit loop bounds and comments referencing mofclient.c behavior

- **Updated `PrepareDrawing()` method**:
  - Stores retrieved background image in `m_pBgImage` for later use
  - Replaced frame-count-based alpha calculation with proper state machine: `m_targetAlphaState += 6` each frame with automatic byte wraparound (0-255)

### AccuracyBar Fixes
- **Fixed degree=0 case**: Added missing assignment for `r==2` case that was falling through without setting `m_speed`
- **Simplified null check in `Render()`**: Removed redundant null check for `m_pHighlight` to match original behavior (only checks `m_running && m_pCursor`)

### Mini_Timer Fixes
- **Corrected return type**: Changed `GetCurrentFrameTime()` from `float` to `double` to match mofclient.c signature
- Added comment explaining float-to-double conversion behavior

### cltMini_Sword_2 Fix
- **Fixed `SetGameDegree()` initialization**: Changed `InitMiniGameTime(0, 3u)` to pass `m_difficultyBaseScore` (Easy=12, Normal=20, Hard=27) as first parameter instead of hardcoded 0, matching original mofclient.c behavior

## Implementation Details
- All changes include detailed comments referencing corresponding mofclient.c offsets and behavior
- Drawing slot indices are initialized once in `InitMiniGameImage()` and remain constant throughout the minigame lifecycle
- Target alpha animation now properly implements the original byte-based state machine with automatic wraparound

https://claude.ai/code/session_01Nw8snuJ4PhP8V2S2rXb6jW