### PR TITLE
Fix Sword minigame scoring logic and initialization

### DIFF
--- a/inc/MiniGame/cltMini_Sword.h
+++ b/inc/MiniGame/cltMini_Sword.h
@@ -87,6 +87,12 @@ public:
     int        m_currentRoundScore;       // +32 (dword 8)
     int        m_finalScore;              // +36 (dword 9)
     int        m_displayScore;            // +40 (dword 10)
+    // mofclient.c：*((float*)this + 520) — point 超過 baseScore 後的加分倍率
+    //   Easy=2.0、Normal=8.0、Hard=4.0。SetGameDegree 寫入，EndStage 讀取。
+    float      m_bonusMultiplier;         // dword 520
+    // mofclient.c：*((_DWORD*)this + 521) — 結算分數上限
+    //   Easy=90、Normal=180、Hard=360。
+    int        m_scoreCap;                // dword 521
     uint16_t   m_point;                   // +36 offset: actually WORD[1982] = +3964
 
     // 5*i + 565 中的「i」剛好是 slot index，所以 slot data 從 dword 565 = byte 2260 開始。

--- a/src/MiniGame/PowerBar.cpp
+++ b/src/MiniGame/PowerBar.cpp
@@ -13,7 +13,7 @@ PowerBar::PowerBar()
     , m_maxRange(200.0f)                  // 1127743488
     , m_decaySpeed(0.0f)
     , m_curOffset(0.0f)
-    , m_running(1)
+    , m_running(0)                        // mofclient.c ctor：byte16 = 0；InitPowerBar 才設 1
     , m_pBar(nullptr)
     , m_pCursor(nullptr)
     , m_highlightUp(0)

--- a/src/MiniGame/cltMini_Sword.cpp
+++ b/src/MiniGame/cltMini_Sword.cpp
@@ -133,6 +133,8 @@ cltMini_Sword::cltMini_Sword()
     , m_currentRoundScore(0)
     , m_finalScore(0)
     , m_displayScore(0)
+    , m_bonusMultiplier(0.0f)
+    , m_scoreCap(0)
     , m_point(0)
     , m_slots{}
     , m_drawNumTime()
@@ -860,7 +862,8 @@ void cltMini_Sword::SetGameDegree(uint8_t degree)
 {
     m_stage = degree;
     m_currentRoundScore = 30;
-    m_difficultyBaseScore = 0;
+    // mofclient.c：*((_DWORD*)this + 520) = 0 在 switch 前先清為 0
+    m_bonusMultiplier = 0.0f;
 
     switch (degree)
     {
@@ -869,8 +872,9 @@ void cltMini_Sword::SetGameDegree(uint8_t degree)
             m_difficultyBaseScore = 20;
             m_spawnInterval       = 800;
             m_gameDegree          = 20;
-            // 每 point > 20 後，額外加 (point-20)*2.0 分上限 90
-            m_displayScore        = 0;
+            // 每 point > 20 後，額外加 (point-20)*2.0 分，上限 90
+            m_scoreCap            = 90;
+            m_bonusMultiplier     = 2.0f;   // 0x40000000
             m_bgResID             = 0x20000023u;
             break;
         case 2:
@@ -878,7 +882,8 @@ void cltMini_Sword::SetGameDegree(uint8_t degree)
             m_difficultyBaseScore = 55;
             m_spawnInterval       = 700;
             m_gameDegree          = 30;
-            m_displayScore        = 0;
+            m_scoreCap            = 180;
+            m_bonusMultiplier     = 8.0f;   // 0x41000000
             m_bgResID             = 0x20000025u;
             break;
         case 4:
@@ -886,7 +891,8 @@ void cltMini_Sword::SetGameDegree(uint8_t degree)
             m_difficultyBaseScore = 40;
             m_spawnInterval       = 600;
             m_gameDegree          = 40;
-            m_displayScore        = 0;
+            m_scoreCap            = 360;
+            m_bonusMultiplier     = 4.0f;   // 0x40800000
             m_bgResID             = 0x20000024u;
             break;
     }
@@ -989,7 +995,10 @@ void cltMini_Sword::StartGame()
     m_slots[m_slotMonsterHead].active = 1;
     m_slots[m_slotMonsterAlt].active  = 0;
 
-    m_lastSpawnTick = 0;
+    // mofclient.c：*((_BYTE *)this + 3966) = -106
+    m_targetAlphaState = static_cast<uint8_t>(-106);
+    // mofclient.c：*((_DWORD *)this + 992) = 0 — hit lock 需在開局時重置
+    m_hitLocked     = 0;
     m_needNewTarget = 0;
     m_curTarget     = 0;
 
@@ -1145,11 +1154,13 @@ void cltMini_Sword::EndStage()
 
             if (m_totalScore)
             {
+                // mofclient.c：bonus = (point - baseScore) * m_bonusMultiplier
+                //   加到 m_finalScore（此時等於 m_winMark），再依 m_scoreCap 截頂
                 double frac = static_cast<double>(GetPoint() - m_difficultyBaseScore);
-                int bonus = static_cast<int>(frac * 2.0); // 近似 mofclient.c 用的 m_dword520 = float
+                int bonus = static_cast<int>(frac * static_cast<double>(m_bonusMultiplier));
                 m_finalScore += bonus;
-                if (static_cast<int>(m_currentRoundScore) < m_finalScore)
-                    m_finalScore = m_currentRoundScore;
+                if (m_scoreCap < m_finalScore)
+                    m_finalScore = m_scoreCap;
             }
 
             int finalValue = m_finalScore;


### PR DESCRIPTION
## Summary
This PR corrects the scoring calculation and initialization logic in the Sword minigame to match the original mofclient.c implementation. The changes involve refactoring hardcoded score multipliers into configurable fields and fixing several initialization issues.

## Key Changes

- **Refactored bonus scoring system**: Replaced hardcoded `2.0` multiplier with a new `m_bonusMultiplier` field that varies by difficulty (Easy=2.0, Normal=8.0, Hard=4.0), set during `SetGameDegree()`

- **Introduced score cap field**: Added `m_scoreCap` member variable to properly cap final scores per difficulty level (Easy=90, Normal=180, Hard=360) instead of using `m_currentRoundScore`

- **Fixed score calculation logic**: Updated `EndStage()` to use the new `m_bonusMultiplier` and `m_scoreCap` fields for accurate bonus point calculation and capping

- **Corrected game initialization**: 
  - Fixed `StartGame()` to properly initialize `m_targetAlphaState` to -106 and reset `m_hitLocked` to 0
  - Removed incorrect `m_lastSpawnTick` initialization
  - Removed unnecessary `m_difficultyBaseScore = 0` assignment in `SetGameDegree()`

- **Fixed PowerBar initialization**: Changed `m_running` default from 1 to 0 in constructor, matching mofclient.c behavior where it's only set to 1 by `InitPowerBar()`

## Implementation Details

The bonus score calculation now follows: `bonus = (point - baseScore) * m_bonusMultiplier`, capped at `m_scoreCap`. This provides per-difficulty scaling that was previously hardcoded, improving maintainability and accuracy to the original implementation.

https://claude.ai/code/session_01Xx5f89gaV8gNtWjZ37VuVU