### PR TITLE
Align button initialization and lesson point system with ground truth

### DIFF
--- a/inc/Logic/cltMiniGame_Button.h
+++ b/inc/Logic/cltMiniGame_Button.h
@@ -10,6 +10,9 @@ public:
     cltMiniGame_Button();
     ~cltMiniGame_Button();
 
+    // 最後一個 int 對應 mofclient.c CreateBtn 的 a15 參數：
+    //   *(_DWORD *)this = a15;
+    // 即按鈕建立後的初始 m_nActive 值。呼叫端會在其後再呼叫 SetActive() 覆寫。
     void CreateBtn(int x, int y,
                    unsigned int imageType,
                    unsigned int resNormal,   uint16_t blockNormal,
@@ -18,7 +21,7 @@ public:
                    unsigned int resDisabled, uint16_t blockDisabled,
                    void (*callback)(unsigned int),
                    unsigned int userData,
-                   int reserved);
+                   int initialActive);
 
     void SetActive(int active);
     void SetBtnState(uint8_t state);

--- a/inc/Logic/cltMyCharData.h
+++ b/inc/Logic/cltMyCharData.h
@@ -37,6 +37,13 @@ public:
     // 呼叫端會把回傳值直接餵給 _wsprintfA 的 "%s"。這裡提供相同語意的 shim，
     // 讓 minigame 等呼叫端能對齊 GT 的呼叫寫法。
     static cltMyCharData* GetMyCharName(cltMyCharData* self);
+
+    // mofclient.c 0x519150：
+    //   void cltMyCharData::IncLessonPt_Sword(this, a2)
+    //   { cltLessonSystem::IncLessonPt_Sword((char*)this + 6568, a2); }
+    // cltMyCharData 內嵌了 cltLessonSystem 於 offset 6568；這裡提供同語意
+    // 的 shim，使小遊戲加分流程能對齊 GT（透過 MyCharData → LessonSystem）。
+    static void IncLessonPt_Sword(cltMyCharData* self, unsigned int value);
 };
 
 extern cltMyCharData g_clMyCharData;

--- a/src/Logic/cltMiniGame_Button.cpp
+++ b/src/Logic/cltMiniGame_Button.cpp
@@ -22,7 +22,7 @@ void cltMiniGame_Button::CreateBtn(int x, int y,
                                    unsigned int resDisabled, uint16_t blockDisabled,
                                    void (*callback)(unsigned int),
                                    unsigned int userData,
-                                   int /*reserved*/)
+                                   int initialActive)
 {
     m_x = x;
     m_y = y;
@@ -37,6 +37,9 @@ void cltMiniGame_Button::CreateBtn(int x, int y,
     m_blockIDs[3] = blockDisabled;
     m_pCallback = callback;
     m_userData = userData;
+    // mofclient.c CreateBtn 0x5BE7A0：*(_DWORD *)this = a15;
+    // a15 是初始 m_nActive，呼叫端後續會在狀態切換時以 SetActive() 覆寫。
+    m_nActive = initialActive;
     m_nState = 0;
 }
 

--- a/src/Logic/cltMyCharData.cpp
+++ b/src/Logic/cltMyCharData.cpp
@@ -1,5 +1,6 @@
 #include "Logic/cltMyCharData.h"
 #include "global.h"
+#include "System/cltLessonSystem.h"
 
 cltMyCharData g_clMyCharData{};
 
@@ -53,4 +54,12 @@ cltMyCharData* cltMyCharData::GetMyCharName(cltMyCharData* self) {
     // 呼叫端 (_wsprintfA(..., fmt, GetMyCharName(...), ...)) 會把回傳值當作
     // 指向角色名稱字元陣列（位於 cltMyCharData 起始位址）的 char*。
     return self;
+}
+
+void cltMyCharData::IncLessonPt_Sword(cltMyCharData* /*self*/, unsigned int value) {
+    // Ground truth 0x519150：
+    //   cltLessonSystem::IncLessonPt_Sword((char*)this + 6568, a2);
+    // cltMyCharData 內嵌 cltLessonSystem 於 offset 6568；本專案以 g_clLessonSystem
+    // 作為全域的 LessonSystem 實例，因此以同一個實例轉發加分呼叫。
+    g_clLessonSystem.IncLessonPt_Sword(value);
 }

--- a/src/MiniGame/cltMini_Sword.cpp
+++ b/src/MiniGame/cltMini_Sword.cpp
@@ -265,6 +265,10 @@ void cltMini_Sword::InitMiniGameImage()
 
     // 3) 13 個按鈕
     //   對齊 mofclient.c 對每個按鈕的 CreateBtn 呼叫 —— 僅以本專案的 API 重排參數。
+    //   CreateBtn 最後一個參數是 initialActive（mofclient.c 直接寫入 *(_DWORD*)this），
+    //   GT 的 13 個按鈕中只有 Main 選單的 Start/Ranking/Exit 與 Help/ShowPoint 傳 1，
+    //   其餘（Ranking 彈窗的 Prev/Next/Back、Help/ShowPoint 關閉鈕、難度三顆、
+    //   EndStage 關閉鈕）皆傳 0。
     auto make = [&](int idx, int x, int y,
                     unsigned int imageType,
                     unsigned int r1, uint16_t b1,
@@ -272,11 +276,12 @@ void cltMini_Sword::InitMiniGameImage()
                     unsigned int r3, uint16_t b3,
                     unsigned int r4, uint16_t b4,
                     void (*cb)(unsigned int),
-                    unsigned int userData)
+                    unsigned int userData,
+                    int initialActive)
     {
         m_buttons[idx].CreateBtn(x, y, imageType,
                                  r1, b1, r2, b2, r3, b3, r4, b4,
-                                 cb, userData, 1);
+                                 cb, userData, initialActive);
     };
 
     auto cast = [](void (*fn)(cltMini_Sword*)) -> void(*)(unsigned int) {
@@ -286,76 +291,65 @@ void cltMini_Sword::InitMiniGameImage()
         return reinterpret_cast<void (*)(unsigned int)>(fn);
     };
 
-    // 主選單三顆（Start / Ranking / Exit）
+    const unsigned int self = reinterpret_cast<unsigned int>(this);
+
+    // 主選單三顆（Start / Ranking / Exit）— GT: initialActive = 1
     make(0,  m_screenX + 37,  m_screenY + 472, 9u,
          0x2200000Au, 0, 0x2200000Au, 3, 0x2200000Au, 6,
-         0x20000014u, 9, cast(&cltMini_Sword::OnBtn_Start),
-         reinterpret_cast<unsigned int>(this));
+         0x20000014u, 9, cast(&cltMini_Sword::OnBtn_Start),   self, 1);
 
     make(1,  m_screenX + 183, m_screenY + 472, 9u,
          0x2200000Au, 1, 0x2200000Au, 4, 0x2200000Au, 7,
-         0x20000014u, 10, cast(&cltMini_Sword::OnBtn_Ranking),
-         reinterpret_cast<unsigned int>(this));
+         0x20000014u, 10, cast(&cltMini_Sword::OnBtn_Ranking), self, 1);
 
     make(2,  m_screenX + 621, m_screenY + 472, 9u,
          0x2200000Au, 2, 0x2200000Au, 5, 0x2200000Au, 8,
-         0x20000014u, 11, cast2(&cltMini_Sword::OnBtn_Exit),
-         reinterpret_cast<unsigned int>(this));
+         0x20000014u, 11, cast2(&cltMini_Sword::OnBtn_Exit),   self, 1);
 
-    // Ranking Pre/Next/Back
+    // Ranking Pre/Next/Back — GT: initialActive = 0
     make(3,  m_uiPos[0] + 17,  m_uiPos[1] + 295, 9u,
          0x2200000Au, 13, 0x2200000Au, 15, 0x2200000Au, 17,
-         0x2200000Au, 19, cast(&cltMini_Sword::OnBtn_RankingPre),
-         reinterpret_cast<unsigned int>(this));
+         0x2200000Au, 19, cast(&cltMini_Sword::OnBtn_RankingPre),  self, 0);
 
     make(4,  m_uiPos[0] + 62,  m_uiPos[1] + 295, 9u,
          0x2200000Au, 14, 0x2200000Au, 16, 0x2200000Au, 18,
-         0x2200000Au, 20, cast(&cltMini_Sword::OnBtn_RankingNext),
-         reinterpret_cast<unsigned int>(this));
+         0x2200000Au, 20, cast(&cltMini_Sword::OnBtn_RankingNext), self, 0);
 
     make(5,  m_uiPos[0] + 220, m_uiPos[1] + 295, 9u,
          0x2200000Au, 21, 0x2200000Au, 22, 0x2200000Au, 23,
-         0x2200000Au, 24, cast(&cltMini_Sword::OnBtn_ExitPopUp),
-         reinterpret_cast<unsigned int>(this));
+         0x2200000Au, 24, cast(&cltMini_Sword::OnBtn_ExitPopUp),   self, 0);
 
-    // Help / ShowPoint
+    // Help / ShowPoint — GT: initialActive = 1
     make(6,  m_screenX + 329, m_screenY + 472, 9u,
          0x1000009Bu, 12, 0x1000009Bu, 14, 0x1000009Bu, 16,
-         0x1000009Bu, 18, cast(&cltMini_Sword::OnBtn_Help),
-         reinterpret_cast<unsigned int>(this));
+         0x1000009Bu, 18, cast(&cltMini_Sword::OnBtn_Help),       self, 1);
 
     make(7,  m_screenX + 475, m_screenY + 472, 9u,
          0x1000009Bu, 13, 0x1000009Bu, 15, 0x1000009Bu, 17,
-         0x1000009Bu, 19, cast(&cltMini_Sword::OnBtn_ShowPoint),
-         reinterpret_cast<unsigned int>(this));
+         0x1000009Bu, 19, cast(&cltMini_Sword::OnBtn_ShowPoint),  self, 1);
 
-    // Help / ShowPoint popup 上的關閉鈕
+    // Help / ShowPoint popup 上的關閉鈕 — GT: initialActive = 0
     make(8,  m_screenX + 566, m_screenY + 513, 9u,
          0x2200000Au, 21, 0x2200000Au, 22, 0x2200000Au, 23,
-         0x2200000Au, 24, cast(&cltMini_Sword::OnBtn_ExitPopUp),
-         reinterpret_cast<unsigned int>(this));
+         0x2200000Au, 24, cast(&cltMini_Sword::OnBtn_ExitPopUp),  self, 0);
 
-    // 難度選擇：Easy / Normal / Hard
+    // 難度選擇：Easy / Normal / Hard — GT: initialActive = 0
     make(9,  m_uiPos[8] + 36,  m_uiPos[9] + 48,  9u,
          0x1000009Bu, 0, 0x1000009Bu, 3, 0x1000009Bu, 6,
-         0x1000009Bu, 9, cast(&cltMini_Sword::OnBtn_DegreeEasy),
-         reinterpret_cast<unsigned int>(this));
+         0x1000009Bu, 9, cast(&cltMini_Sword::OnBtn_DegreeEasy),   self, 0);
 
     make(10, m_uiPos[8] + 36,  m_uiPos[9] + 102, 9u,
          0x1000009Bu, 1, 0x1000009Bu, 4, 0x1000009Bu, 7,
-         0x1000009Bu, 10, cast(&cltMini_Sword::OnBtn_DegreeNormal),
-         reinterpret_cast<unsigned int>(this));
+         0x1000009Bu, 10, cast(&cltMini_Sword::OnBtn_DegreeNormal), self, 0);
 
     make(11, m_uiPos[8] + 36,  m_uiPos[9] + 156, 9u,
          0x1000009Bu, 2, 0x1000009Bu, 5, 0x1000009Bu, 8,
-         0x1000009Bu, 11, cast(&cltMini_Sword::OnBtn_DegreeHard),
-         reinterpret_cast<unsigned int>(this));
+         0x1000009Bu, 11, cast(&cltMini_Sword::OnBtn_DegreeHard),  self, 0);
 
-    // EndStage popup 關閉鈕
+    // EndStage popup 關閉鈕 — GT: initialActive = 0
     make(12, m_uiPos[2] + 215, m_uiPos[3] + 170, 9u,
          0x2200000Au, 21, 0x2200000Au, 22, 0x2200000Au, 23,
-         0x2200000Au, 24, cast(&cltMini_Sword::OnBtn_ExitPopUp),
-         reinterpret_cast<unsigned int>(this));
+         0x2200000Au, 24, cast(&cltMini_Sword::OnBtn_ExitPopUp),   self, 0);
 
     // DrawNum 初始化
     m_drawNumTime .InitDrawNum(9u, 0x22000007u, 0x11u, 0);
@@ -393,7 +387,11 @@ uint16_t cltMini_Sword::GetPoint()            { return m_point; }
 
 void cltMini_Sword::IncLessonPt_Sword(unsigned int v)
 {
-    g_clLessonSystem.IncLessonPt_Sword(v);
+    // mofclient.c 0x5A6100：
+    //   cltMyCharData::IncLessonPt_Sword(cltMoF_BaseMiniGame::m_pclMyChatData, a2);
+    // GT 的加分流程是 cltMini_Sword → cltMyCharData → cltLessonSystem，
+    // 不是直接呼叫 g_clLessonSystem。
+    cltMyCharData::IncLessonPt_Sword(cltMoF_BaseMiniGame::m_pclMyChatData, v);
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary
This PR aligns the mini-game button initialization and lesson point system with the ground truth (mofclient.c) implementation. The changes involve properly handling button active states during creation and fixing the lesson point increment call chain to route through `cltMyCharData` instead of directly calling `cltLessonSystem`.

## Key Changes

- **Button initialization**: Added `initialActive` parameter to `CreateBtn()` to properly set the initial `m_nActive` state for each button. Different buttons have different initial states:
  - Main menu buttons (Start/Ranking/Exit) and Help/ShowPoint: `initialActive = 1`
  - Ranking popup buttons (Prev/Next/Back), popup close buttons, difficulty selection, and EndStage close button: `initialActive = 0`

- **Lesson point system**: Changed `cltMini_Sword::IncLessonPt_Sword()` to route through `cltMyCharData::IncLessonPt_Sword()` instead of directly calling `g_clLessonSystem.IncLessonPt_Sword()`. This matches the ground truth call chain where `cltMyCharData` internally delegates to its embedded `cltLessonSystem` instance at offset 6568.

- **Code refactoring**: Extracted `self` pointer to a local variable to reduce repetitive `reinterpret_cast` calls and improve readability.

- **Documentation**: Added detailed comments explaining the ground truth behavior and the rationale for each implementation choice.

## Implementation Details

- The `initialActive` parameter in `CreateBtn()` directly corresponds to the `a15` parameter in mofclient.c, which sets `m_nActive` immediately after button creation. Callers may subsequently override this via `SetActive()`.
- The new `cltMyCharData::IncLessonPt_Sword()` static method acts as a shim that forwards calls to the global `g_clLessonSystem` instance, maintaining the same logical call chain as the ground truth while working with the project's architecture.

https://claude.ai/code/session_012qty95pK3F9KuZZs3f8ABH