### PR TITLE
Fix CHospital difficulty initialization and add CBedstead size validation

### DIFF
--- a/src/MiniGame/CHospital.cpp
+++ b/src/MiniGame/CHospital.cpp
@@ -22,10 +22,11 @@ CHospital::CHospital()
     , m_imgNumber()
     , m_selectRow(0)
     , m_selectCol(0)
-    , m_difficulty(5)
+    , m_difficulty(0)
 {
-    // mofclient.c：建構子最後把 g_GAMESCORE 歸零、設定預設難度 5（將被
-    // InitHospital 覆寫成 0/1/2），並建立游標動畫 (resID 0x20000032 blocks 8/9)。
+    // mofclient.c：建構子不寫入 m_difficulty（由 InitHospital 設定 0/1/2）；
+    // LOBYTE(v11)=5 是 MSVC __ehstate，非 m_difficulty。
+    // 建構子歸零 g_GAMESCORE 及 m_state，並建立游標動畫 (resID 0x20000032 blocks 8/9)。
     g_GAMESCORE = 0;
     m_state     = 0;
 

--- a/src/MiniGame/PatientRecallMgr.cpp
+++ b/src/MiniGame/PatientRecallMgr.cpp
@@ -4,6 +4,11 @@
 
 #include "MiniGame/CMedical.h"   // CBedstead 完整定義
 
+// mofclient.c: CBedstead 在 eh vector constructor iterator 中確認為 0xC8 bytes，
+// 且 InitPatientRecallMgr 以 +200 byte 步進遍歷 9 張連續病床。
+static_assert(sizeof(CBedstead) == 200,
+              "CBedstead must be exactly 200 bytes to match ground truth bed array stride");
+
 // =========================================================================
 // PatientRecallMgr — 對齊 mofclient.c 0x5B04F0 / 0x5B0530 / 0x5B05C0 / 0x5B0620
 // =========================================================================


### PR DESCRIPTION
## Summary
This PR corrects the CHospital constructor's difficulty initialization and adds a compile-time validation for CBedstead's memory layout to match the original mofclient.c implementation.

## Key Changes
- **CHospital constructor**: Changed `m_difficulty` initialization from `5` to `0`
  - The value `5` was actually an MSVC `__ehstate` variable, not the difficulty setting
  - Difficulty is now properly set by `InitHospital()` instead of the constructor
  - Updated comments to clarify the distinction between `__ehstate` and `m_difficulty`

- **PatientRecallMgr**: Added `static_assert` to validate `CBedstead` size
  - Enforces that `CBedstead` is exactly 200 bytes, matching the stride used in `InitPatientRecallMgr`
  - This validates the memory layout against the original mofclient.c implementation where 9 consecutive beds are traversed with +200 byte steps
  - Provides compile-time safety for the bed array iteration logic

## Implementation Details
The changes align the C++ implementation more closely with the original mofclient.c binary, ensuring correct initialization order and memory layout assumptions.

https://claude.ai/code/session_01YPpMLgModHrXR8uNbvCWLQ