### PR TITLE
Rename m_drawAlphaBox to m_rankDrawCounter in Exorcist 2 minigame

### DIFF
--- a/src/MiniGame/cltMini_Exorcist_2.cpp
+++ b/src/MiniGame/cltMini_Exorcist_2.cpp
@@ -405,7 +405,7 @@ void cltMini_Exorcist_2::Draw()
 
     if (g_cGameExorcist_2State == 7)
     {
-        if (!m_drawAlphaBox)
+        if (!m_rankDrawCounter)
             DrawRanking(static_cast<std::uint16_t>(m_uiPos[0]),
                         static_cast<std::uint16_t>(m_uiPos[1]), 0);
     }
@@ -473,7 +473,7 @@ void cltMini_Exorcist_2::Init_Ranking()
     std::memset(m_ranking, 0, sizeof(m_ranking));
 
     RequestRanking(0x29u, m_curRankPage);
-    m_drawAlphaBox = 1;
+    m_rankDrawCounter = 1;
     g_cGameExorcist_2State = 7;
 }
 


### PR DESCRIPTION
## Summary
Refactored variable naming in the Exorcist 2 minigame to use a more descriptive and semantically accurate name for the ranking display counter.

## Changes
- Renamed `m_drawAlphaBox` to `m_rankDrawCounter` throughout the ranking display logic
  - Updated the condition check in `Draw()` method (line 408)
  - Updated the initialization in `Init_Ranking()` method (line 476)

## Details
The variable `m_rankDrawCounter` better reflects its actual purpose as a counter for controlling when the ranking should be drawn, rather than the misleading name `m_drawAlphaBox` which suggested it was related to alpha blending of a box element. This improves code clarity and maintainability.

https://claude.ai/code/session_01Mgt3QVvVgqx7RBGwDEpGap