### PR TITLE
Fix bow minigame coordinate initialization and slot indexing

### DIFF
--- a/inc/MiniGame/cltMini_Bow.h
+++ b/inc/MiniGame/cltMini_Bow.h
@@ -125,8 +125,8 @@ public:
     std::uint16_t m_startAreaX;            // 射出起始 X
     std::uint16_t m_startAreaY;            // 射出起始 Y
     int           m_hitTargetY;            // 箭命中的 Y 座標（靶中心）
-    std::uint16_t m_initArrowX;            // 箭初始 X（= screenX 偏移）
-    std::uint16_t m_initArrowY;            // 箭初始 Y（= screenY 偏移）
+    int           m_initArrowX;            // DWORD[1253] 箭初始 X（= screenX + 400）
+    int           m_initArrowY;            // DWORD[1254] 箭初始 Y（= screenY + 367）
     std::uint8_t  m_shootCounter;          // 射擊動畫計數
     std::uint8_t  m_curArrowSlot;          // 目前箭的 slot 索引（初始 2）
     std::uint8_t  m_curTargetSlot;         // 目前靶的 slot 索引

--- a/src/MiniGame/cltBow2_Char.cpp
+++ b/src/MiniGame/cltBow2_Char.cpp
@@ -47,10 +47,10 @@ void cltBow2_Char::Initalize(float radius, std::uint8_t degree,
         m_resID = 0x0C00029Du;
         break;
     case 2:
-        m_resID = 0x0B00004Bu;
+        m_resID = 0x0B00073Bu;  // 184551227
         break;
     case 4:
-        m_resID = 0x0B00004Cu;
+        m_resID = 0x0B00073Cu;  // 184551228
         break;
     }
 

--- a/src/MiniGame/cltBow2_Spear.cpp
+++ b/src/MiniGame/cltBow2_Spear.cpp
@@ -49,8 +49,8 @@ void cltBow2_Spear::Create(std::uint8_t posIndex, std::uint8_t direction,
     m_centerX = static_cast<float>((g_Game_System_Info.ScreenWidth - 800) / 2) + 403.0f;
     m_centerY = static_cast<float>((g_Game_System_Info.ScreenHeight - 600) / 2) + 272.0f;
 
-    m_radius    = 300.0f;
-    m_maxDist   = 50000.0f;
+    m_radius    = 216.0f;    // IEEE 1129840640
+    m_maxDist   = 46656.0f;  // IEEE 1194737664 (= 216^2)
     m_intercept = 0.0f;
     m_moveType  = moveType;
 

--- a/src/MiniGame/cltMini_Bow.cpp
+++ b/src/MiniGame/cltMini_Bow.cpp
@@ -50,11 +50,12 @@ cltMini_Bow::cltMini_Bow()
     memset(m_arrowScores, 0, sizeof(m_arrowScores));
     memset(m_arrowNumXPos, 0, sizeof(m_arrowNumXPos));
 
-    // 對齊 mofclient.c：arrowY 初始取自 screenY 偏移
-    m_initArrowX = static_cast<std::uint16_t>(m_screenX);
-    m_initArrowY = static_cast<std::uint16_t>(m_screenY);
-    m_arrowX = m_initArrowX;
-    m_arrowY = m_initArrowY;
+    // 對齊 mofclient.c：建構子讀取尚未初始化的 DWORD[1253]/[1254]，
+    // InitMiniGameImage 後才設為 screenX+400 / screenY+367。
+    m_initArrowX = 0;
+    m_initArrowY = 0;
+    m_arrowX = 0;
+    m_arrowY = 0;
 
     g_cGameBowState = 0;
     m_prevState      = 100;
@@ -332,9 +333,10 @@ void cltMini_Bow::SetGameDegree(std::uint8_t degree)
         1000 * readyTime,
         reinterpret_cast<unsigned int>(this),
         1000u, 1,
+        nullptr, nullptr,
         reinterpret_cast<cltTimer::TimerCallback>(OnTimer_TimeOutReadyTime),
         reinterpret_cast<cltTimer::TimerCallback>(OnTimer_DecreaseReadyTime),
-        nullptr, nullptr, nullptr);
+        nullptr);
 
     for (int i = 0; i < kButtonCount; ++i)
         m_buttons[i].SetActive(0);
@@ -357,8 +359,8 @@ void cltMini_Bow::Ready()
 void cltMini_Bow::StartGame()
 {
     m_drawNumReady.SetActive(0);
-    m_startAreaX   = static_cast<std::uint16_t>(m_screenX);
-    m_startAreaY   = static_cast<std::uint16_t>(m_screenY);
+    m_startAreaX   = static_cast<std::uint16_t>(m_initArrowX); // WORD[2506] = low16(DWORD[1253])
+    m_startAreaY   = static_cast<std::uint16_t>(m_initArrowY); // WORD[2508] = low16(DWORD[1254])
     m_arrowBlockID = 14;
     m_curTargetSlot = 0;
 
@@ -456,8 +458,7 @@ void cltMini_Bow::EndGame()
 
         if (m_totalPoint < static_cast<std::uint16_t>(m_difficultyBaseScore))
         {
-            // 失敗
-            m_slots[m_slotLose + 115].active = 1; // 原始碼用 slot offset 計算
+            // 失敗 — 原始碼 DWORD[5*(BYTE[609]+115)] = DWORD[5*m_slotLose+575] = m_slots[m_slotLose].active
             m_slots[m_slotLose].active = 1;
         }
         else
@@ -609,7 +610,7 @@ void cltMini_Bow::ShootArrow()
 
         if (m_arrowY <= static_cast<std::uint16_t>(hitY))
         {
-            m_arrowY = static_cast<std::uint16_t>(m_slots[1].x); // WORD[2504] mapped to slot[1] data
+            m_arrowY = static_cast<std::uint16_t>(m_hitTargetY); // WORD[2504] = low16(DWORD[1252])
             CheckPoint();
         }
     }
@@ -660,13 +661,14 @@ int cltMini_Bow::CheckPoint()
     {
         // 命中
         char grade = 3;
-        m_slots[m_curArrowSlot].y     = m_hitTargetY;
-        m_slots[m_curTargetSlot].active = 0;
-        m_slots[m_curTargetSlot].x      = m_targetX; // 記錄靶位置
+        m_slots[m_curArrowSlot].y       = m_hitTargetY;
+        m_slots[m_curTargetSlot].active  = 0;
 
+        // 對齊 mofclient.c：DWORD[5*curTargetSlot+583] 寫入下一個 slot 的 x
         ++m_curTargetSlot;
-        m_slots[m_curTargetSlot].active = 1;
-        m_slots[m_curTargetSlot].y      = m_hitTargetY;
+        m_slots[m_curTargetSlot].x       = m_targetX;
+        m_slots[m_curTargetSlot].active  = 1;
+        m_slots[m_curTargetSlot].y       = m_hitTargetY;
 
         // 計分
         if (static_cast<std::uint16_t>(diff) == 0)
@@ -1028,10 +1030,10 @@ after_ranking:
 // ---------------------------------------------------------------------------
 void cltMini_Bow::InitMiniGameImage()
 {
-    // 計算關鍵座標
-    m_hitTargetY = m_screenY + 157;
-    int arrowAreaX = m_screenX + 400;
-    int arrowAreaY = m_screenY + 367;
+    // 計算關鍵座標（對齊 mofclient.c DWORD[1252..1254]）
+    m_hitTargetY  = m_screenY + 157;
+    m_initArrowX  = m_screenX + 400;
+    m_initArrowY  = m_screenY + 367;
 
     // --- Slot 索引設定 ---
     m_curArrowSlot  = 2;
@@ -1061,7 +1063,7 @@ void cltMini_Bow::InitMiniGameImage()
     // Slot 1: 靶（右）
     m_slots[1].resID   = 0x10000022u;
     m_slots[1].blockID = 10;
-    m_slots[1].x       = arrowAreaX;
+    m_slots[1].x       = m_initArrowX;
     m_slots[1].y       = m_hitTargetY;
 
     // Slots 2-10: 箭（block 8, 0-7）


### PR DESCRIPTION
## Summary
This PR fixes several coordinate initialization and slot indexing issues in the bow minigame implementation to align with the original mofclient.c behavior. The changes address improper initialization of arrow positions, incorrect slot offset calculations, and resource ID corrections for bow2 characters.

## Key Changes

- **Arrow Position Initialization**: Changed `m_initArrowX` and `m_initArrowY` from being initialized with `screenX`/`screenY` to `0`, with proper initialization deferred to `InitMiniGameImage()` where they are set to `screenX + 400` and `screenY + 367` respectively. This aligns with the original code which reads uninitialized DWORD[1253]/[1254] in the constructor.

- **Data Type Corrections**: Updated `m_initArrowX` and `m_initArrowY` from `std::uint16_t` to `int` to properly represent the full 32-bit values (DWORD[1253]/[1254]) instead of just the low 16 bits.

- **Slot Indexing Fix**: Corrected `StartGame()` to use `m_initArrowX`/`m_initArrowY` instead of `m_screenX`/`m_screenY` for `m_startAreaX`/`m_startAreaY` initialization.

- **Slot Offset Calculation**: Fixed `EndGame()` to use correct slot indexing (`m_slots[m_slotLose].active`) instead of the incorrect offset calculation (`m_slots[m_slotLose + 115].active`).

- **Arrow Hit Target Assignment**: Changed `ShootArrow()` to assign `m_hitTargetY` instead of `m_slots[1].x` to `m_arrowY`, fixing the incorrect slot data reference.

- **CheckPoint() Slot Logic**: Reordered slot assignments in `CheckPoint()` to correctly write the target X position to the next slot (after incrementing `m_curTargetSlot`) rather than the current slot, aligning with the original DWORD offset calculations.

- **Bow2 Character Resources**: Updated resource IDs for bow2 character degrees 2 and 4 from `0x0B00004B`/`0x0B00004C` to `0x0B00073B`/`0x0B00073C`.

- **Bow2 Spear Physics**: Adjusted spear radius from `300.0f` to `216.0f` and max distance from `50000.0f` to `46656.0f` (216²), correcting the collision detection parameters.

- **Timer Callback Signature**: Fixed timer registration call to match the correct callback function signature by reordering parameters.

## Implementation Details
All changes include detailed comments referencing the corresponding DWORD offsets and memory locations from the original mofclient.c implementation to ensure maintainability and clarity of the alignment work.

https://claude.ai/code/session_01W5TojTj64nfq2UhxhNAy2X