### PR TITLE
Refactor mini-game constructors to rely on memset initialization

### DIFF
--- a/src/MiniGame/cltBow2_Char.cpp
+++ b/src/MiniGame/cltBow2_Char.cpp
@@ -11,11 +11,8 @@
 // mofclient.c @ 005B7CA0 — 建構子
 // ---------------------------------------------------------------------------
 cltBow2_Char::cltBow2_Char()
-    : m_initPosX(0), m_initPosY(0), m_curPosX(0), m_curPosY(0),
-      m_resID(0), m_frame(0), m_direction(0), m_frameCount(0),
-      m_animCounter(0), m_radius(0), m_blockIDBase(0),
-      m_pImage(nullptr), m_active(0)
 {
+    // GT: 只設 vftable（自動），不初始化任何成員
 }
 
 // ---------------------------------------------------------------------------

--- a/src/MiniGame/cltBow2_Spear.cpp
+++ b/src/MiniGame/cltBow2_Spear.cpp
@@ -14,8 +14,7 @@
 // ---------------------------------------------------------------------------
 stBowSpear::stBowSpear()
 {
-    m_active = 0;
-    // cltBow2_Spear 由其自身建構子初始化
+    // GT: 只呼叫 cltBow2_Spear 建構子（C++ 自動處理），不初始化 m_active
 }
 
 stBowSpear::~stBowSpear()
@@ -27,12 +26,9 @@ stBowSpear::~stBowSpear()
 // cltBow2_Spear
 // ---------------------------------------------------------------------------
 cltBow2_Spear::cltBow2_Spear()
-    : m_posX(0), m_posY(0), m_frame(0), m_animCounter(0),
-      m_radius(0), m_maxDist(0), m_active(0),
-      m_centerX(0), m_centerY(0), m_pImage(nullptr),
-      m_speedX(0), m_speedY(0), m_moveType(0),
-      m_intercept(0), m_dirX(0), m_dirY(0)
+    : m_active(0)
 {
+    // GT: 只設 vftable（自動）+ *((_DWORD *)this + 10) = 0 即 m_active
 }
 
 cltBow2_Spear::~cltBow2_Spear()

--- a/src/MiniGame/cltMini_Bow.cpp
+++ b/src/MiniGame/cltMini_Bow.cpp
@@ -27,42 +27,24 @@ extern unsigned char g_cGameBowState;
 // mofclient.c @ 005B2900 — 建構子
 // ---------------------------------------------------------------------------
 cltMini_Bow::cltMini_Bow()
-    : m_bgResID(0), m_totalScore(0), m_difficultyBaseScore(0),
-      m_winMark(0), m_currentRoundScore(0), m_finalScore(0), m_displayScore(0),
-      m_bonusMultiplier(0), m_scoreCap(0),
-      m_arrowShotCount(0), m_arrowLoaded(0), m_arrowShooting(0),
-      m_arrowBlockID(0), m_targetMoveSpeed(0), m_totalPoint(0),
-      m_firstTimeEnd(0), m_shootSpeed(0), m_targetX(0),
-      m_arrowX(0), m_arrowY(0), m_startAreaX(0), m_startAreaY(0),
-      m_hitTargetY(0), m_initArrowX(0), m_initArrowY(0),
-      m_shootCounter(0), m_curArrowSlot(0), m_curTargetSlot(0),
-      m_slotRanking(0), m_slotSelectDeg(0), m_slotHelp(0), m_slotShowPoint(0),
-      m_slotWin(0), m_slotLose(0),
-      m_slotIdx_11(0), m_slotIdx_12(0), m_slotIdx_13(0),
-      m_slotIdx_14(0), m_slotIdx_15(0), m_slotIdx_16(0),
-      m_timerHandle(0), m_pollFrame(0), m_prevState(100),
-      m_drawAlphaBox(0), m_showTime2(0), m_difficulty(0),
-      m_finalReady(0), m_serverAck(0), m_serverResult(0), m_serverValid(0),
-      m_startTick(0), m_serverTimeMs(0), m_exitTick(0),
-      m_pBgImage(nullptr)
 {
+    // GT: memset((char*)this + 2300, 0, 0x3E8u) — 清除 slots 陣列
     memset(m_slots, 0, sizeof(m_slots));
-    memset(m_arrowScores, 0, sizeof(m_arrowScores));
-    memset(m_arrowNumXPos, 0, sizeof(m_arrowNumXPos));
 
-    // 對齊 mofclient.c：建構子讀取尚未初始化的 DWORD[1253]/[1254]，
-    // InitMiniGameImage 後才設為 screenX+400 / screenY+367。
-    m_initArrowX = 0;
-    m_initArrowY = 0;
-    m_arrowX = 0;
-    m_arrowY = 0;
+    // GT: BYTE[4916] = 0, bytes 4917-4926 = 0 — 清除射箭計數與得分
+    m_arrowShotCount = 0;
+    memset(m_arrowScores, 0, sizeof(m_arrowScores));
+
+    // GT: 特定欄位歸零
+    m_arrowLoaded = 0;
+    m_totalPoint  = 0;
+    m_pollFrame   = 0;
+    m_timerHandle = 0;
 
     g_cGameBowState = 0;
-    m_prevState      = 100;
-    m_showTime2      = 0;
-    m_showTime       = 0;
-    m_timerHandle    = 0;
-    m_pollFrame      = 0;
+    m_prevState     = 100;
+    m_showTime2     = 0;
+    m_showTime      = 0;
 
     InitMiniGameImage();
     InitBtnFocus();

--- a/src/MiniGame/cltMini_Bow_2.cpp
+++ b/src/MiniGame/cltMini_Bow_2.cpp
@@ -26,31 +26,28 @@ extern unsigned char g_cGameBow_2State;
 // mofclient.c @ 005B5010 — 建構子
 // ---------------------------------------------------------------------------
 cltMini_Bow_2::cltMini_Bow_2()
-    : m_bgResID(0), m_totalScore(0), m_difficultyBaseScore(0),
-      m_winMark(0), m_currentRoundScore(0), m_finalScore(0), m_displayScore(0),
-      m_bonusMultiplier(0), m_scoreCap(0),
-      m_pLifeBarImage(nullptr), m_pBgImage(nullptr),
-      m_timerLiveTime(0), m_timerNormalSpear(0), m_timerSnipeSpear(0),
-      m_timerOctetSpear(0), m_timer2VolleySpear(0), m_timerRainSpear(0),
-      m_timerHorizonSpear(0),
-      m_liveTime(0), m_liveTimeChanged(0),
-      m_slotSelectDeg(0), m_slotHelp(0), m_slotShowPoint(0),
-      m_slotWin(0), m_slotLose(0),
-      m_alphaWhiteValue(0), m_alphaRedValue(0), m_hitPhase(0),
-      m_isHit(0), m_pollFrame(0),
-      m_firstTimeEnd(0), m_serverAck(0), m_serverResult(0), m_serverValid(0),
-      m_startTick(0), m_exitTick(0),
-      m_prevState(100), m_drawAlphaBox(0), m_showTime2(0), m_difficulty(0)
 {
-    memset(m_slotImages, 0, sizeof(m_slotImages));
-    memset(m_slots, 0, sizeof(m_slots));
-
+    // GT: 子物件建構後立即呼叫 InitMiniGameImage（內部會 memset slots）
     InitMiniGameImage();
 
-    m_showTime  = 1;
+    // GT: BYTE[49] = 1
+    m_showTime = 1;
+
+    // GT: DWORD[3934..3940] = 0 — 清除 7 個 timer handles
+    m_timerLiveTime     = 0;
+    m_timerNormalSpear  = 0;
+    m_timerSnipeSpear   = 0;
+    m_timerOctetSpear   = 0;
+    m_timer2VolleySpear = 0;
+    m_timerRainSpear    = 0;
+    m_timerHorizonSpear = 0;
+
+    // GT: DWORD[3949] = 0
+    m_pollFrame = 0;
+
+    // GT: BYTE[2061] = 100, BYTE[568] = 0
     m_prevState = 100;
     m_showTime2 = 0;
-    m_difficulty = 0;
 
     InitBtnFocus();
 }


### PR DESCRIPTION
## Summary
This PR refactors the constructors of several mini-game classes to remove redundant member variable initializations and instead rely on `memset` calls to zero-initialize memory regions. This aligns the code with the original mofclient.c implementation and reduces constructor boilerplate.

## Key Changes

- **cltMini_Bow**: Removed explicit member initializer list and replaced with targeted `memset` calls for `m_slots` and `m_arrowScores`, followed by selective initialization of specific fields (`m_arrowLoaded`, `m_totalPoint`, `m_pollFrame`, `m_timerHandle`). Removed initialization of `m_arrowNumXPos` to match original behavior.

- **cltMini_Bow_2**: Removed extensive member initializer list and moved `InitMiniGameImage()` call to the beginning of the constructor body (which internally performs `memset` on slots). Kept only essential field initializations (`m_showTime`, timer handles, `m_pollFrame`, `m_prevState`, `m_showTime2`).

- **cltBow2_Spear**: Simplified `stBowSpear` constructor to rely on C++ automatic vftable initialization without explicit `m_active` assignment. Reduced `cltBow2_Spear` initializer list to only `m_active(0)`, removing all other member initializations.

- **cltBow2_Char**: Removed all member initializations from the initializer list, relying solely on automatic vftable setup by C++.

## Implementation Details

- The changes preserve the original mofclient.c behavior where `memset` operations zero-initialize large memory blocks (e.g., slots arrays) rather than individual member assignments.
- Constructor bodies now include clarifying comments referencing the original assembly offsets and operations (e.g., "GT: memset((char*)this + 2300, 0, 0x3E8u)").
- Only fields that require non-zero initialization or are explicitly set in the original code are now initialized in the constructor body.

https://claude.ai/code/session_01XJdBfAKtcKGEHATUtm1oxV