### PR TITLE
Fix alpha box rendering in bow mini-game by calling Draw instead of PrepareDrawing

### DIFF
--- a/src/MiniGame/cltMini_Bow.cpp
+++ b/src/MiniGame/cltMini_Bow.cpp
@@ -923,9 +923,12 @@ void cltMini_Bow::PrepareDrawing()
         }
     }
 
-    // 半透明遮罩
+    // 半透明遮罩：GT 在 slot loop 後直接呼叫 Draw（vtable+28），而非 PrepareDrawing。
+    // 原因：cltMini_Bow::Draw() 未對 m_alphaBox 作任何動作，遮罩只能靠 PrepareDrawing
+    // 中的這個提前 Draw 呼叫來渲染，好插在 slot 與 button 之間的 Z 序。
+    // mofclient.c 359126-359127。
     if (m_drawAlphaBox)
-        m_alphaBox.PrepareDrawing();
+        m_alphaBox.Draw();
 
     // 按鈕
     for (int i = 0; i < kButtonCount; ++i)


### PR DESCRIPTION
## Summary
Fixed the rendering order of the semi-transparent alpha box in the bow mini-game by changing the method call from `PrepareDrawing()` to `Draw()`.

## Key Changes
- Changed `m_alphaBox.PrepareDrawing()` to `m_alphaBox.Draw()` in the `cltMini_Bow::PrepareDrawing()` method
- Updated comments to explain the rationale: GT calls `Draw()` directly via vtable+28 after the slot loop, not `PrepareDrawing()`
- The alpha box needs to be rendered in `PrepareDrawing()` to maintain correct Z-ordering between slots and buttons, since `cltMini_Bow::Draw()` doesn't handle the alpha box

## Implementation Details
- The change ensures the semi-transparent mask renders at the correct depth in the visual hierarchy
- This allows the alpha box to appear between the slot elements and button elements as intended
- References mofclient.c lines 359126-359127 for context on the GT rendering behavior

https://claude.ai/code/session_01Y3XpWUnapKTML3msYS33fj