### PR TITLE
Remove null pointer checks in bow minigame drawing code

### DIFF
--- a/src/MiniGame/cltBow2_Char.cpp
+++ b/src/MiniGame/cltBow2_Char.cpp
@@ -160,19 +160,17 @@ void cltBow2_Char::PrepareDrawing()
     GameImage* pImg = cltMoF_BaseMiniGame::m_pclImageMgr->GetGameImage(
         9u, m_resID, 0, 1);
 
+    // GT: 無 nullptr 防護；直接寫入 GameImage 欄位（mofclient.c 362135-362147）。
     m_pImage = pImg;
-    if (pImg)
-    {
-        pImg->m_fPosX           = m_curPosX;
-        pImg->SetBlockID(static_cast<unsigned short>(m_frame));
-        pImg->m_bFlag_447       = true;
-        pImg->m_fPosY           = m_curPosY;
-        pImg->m_bFlag_446       = true;
-        pImg->m_bVertexAnimation = false;
+    pImg->m_fPosX           = m_curPosX;
+    pImg->SetBlockID(static_cast<unsigned short>(m_frame));
+    pImg->m_bFlag_447       = true;
+    pImg->m_fPosY           = m_curPosY;
+    pImg->m_bFlag_446       = true;
+    pImg->m_bVertexAnimation = false;
 
-        if (m_direction > 4)
-            pImg->m_bFlipX = true;
-    }
+    if (m_direction > 4)
+        pImg->m_bFlipX = true;
 
     m_animCounter += 0.5f;
     m_frame = m_blockIDBase + static_cast<int>(m_animCounter);

--- a/src/MiniGame/cltBow2_Spear.cpp
+++ b/src/MiniGame/cltBow2_Spear.cpp
@@ -174,16 +174,14 @@ void cltBow2_Spear::PrepareDrawing()
     GameImage* pImg = cltMoF_BaseMiniGame::m_pclImageMgr->GetGameImage(
         9u, 0x0C00029Eu, 0, 1);
 
+    // GT: 無 nullptr 防護；直接依序寫入 GameImage 欄位（mofclient.c 361958-361968）。
     m_pImage = pImg;
-    if (pImg)
-    {
-        pImg->m_fPosX = m_posX;
-        pImg->m_fPosY = m_posY;
-        pImg->SetBlockID(static_cast<unsigned short>(m_frame));
-        pImg->m_bFlag_447 = true;
-        pImg->m_bFlag_446 = true;
-        pImg->m_bVertexAnimation = false;
-    }
+    pImg->m_fPosX = m_posX;
+    pImg->SetBlockID(static_cast<unsigned short>(m_frame));
+    pImg->m_bFlag_447 = true;
+    pImg->m_fPosY = m_posY;
+    pImg->m_bFlag_446 = true;
+    pImg->m_bVertexAnimation = false;
 
     m_animCounter += 0.2f;
     m_frame = static_cast<int>(m_animCounter);

--- a/src/MiniGame/cltMini_Bow.cpp
+++ b/src/MiniGame/cltMini_Bow.cpp
@@ -31,9 +31,22 @@ cltMini_Bow::cltMini_Bow()
     // GT: memset((char*)this + 2300, 0, 0x3E8u) — 清除 slots 陣列
     memset(m_slots, 0, sizeof(m_slots));
 
+    // GT: 先把 WORD[2506]/WORD[2508] (m_startAreaX/Y) 存到暫存，之後寫回箭座標。
+    //     構造子階段這兩者通常為 0；StartGame 才會填入真正的起始座標。
+    const std::uint16_t v2 = m_startAreaX;
+    const std::uint16_t v3 = m_startAreaY;
+
+    // GT: DWORD[1232] = 0 — m_targetX 清零。
+    m_targetX = 0;
+
     // GT: BYTE[4916] = 0, bytes 4917-4926 = 0 — 清除射箭計數與得分
     m_arrowShotCount = 0;
     memset(m_arrowScores, 0, sizeof(m_arrowScores));
+
+    // GT: WORD[2492]/WORD[2493] = saved values — m_arrowX/m_arrowY 回填。
+    //     必須在 InitMiniGameImage 之前，因為 slot 2..10 的初值會用到它們。
+    m_arrowX = v2;
+    m_arrowY = v3;
 
     // GT: 特定欄位歸零
     m_arrowLoaded = 0;


### PR DESCRIPTION
## Summary
This PR removes defensive null pointer checks in the bow minigame drawing code and reorganizes field initialization in the bow constructor. The changes align with the original game code behavior where null checks were not performed.

## Key Changes

- **cltBow2_Char.cpp**: Removed null pointer check before accessing `pImg` fields in `PrepareDrawing()`. The GameImage pointer is now used directly without validation, matching the original implementation (mofclient.c 362135-362147).

- **cltBow2_Spear.cpp**: Removed null pointer check before accessing `pImg` fields in `PrepareDrawing()`. Field assignments are now performed unconditionally, matching the original implementation (mofclient.c 361958-361968).

- **cltMini_Bow.cpp**: Reorganized constructor initialization to preserve starting area coordinates before clearing related fields. The `m_startAreaX` and `m_startAreaY` values are now saved and restored to `m_arrowX` and `m_arrowY` respectively, ensuring proper arrow position initialization before `InitMiniGameImage()` is called.

## Implementation Details

The changes in `cltMini_Bow.cpp` constructor follow a specific initialization sequence:
1. Save `m_startAreaX` and `m_startAreaY` to temporary variables
2. Clear `m_targetX` to 0
3. Clear arrow shot count and scores
4. Restore saved coordinates to `m_arrowX` and `m_arrowY` before image initialization

This ordering is critical because slot initialization (2-10) depends on the arrow position values being set correctly.

https://claude.ai/code/session_01N4mKunEmuivPwhrpXmAAwv