### PR TITLE
Refactor chat command parsing to match ground truth behavior

### DIFF
--- a/inc/Info/cltClientCharKindInfo.h
+++ b/inc/Info/cltClientCharKindInfo.h
@@ -33,6 +33,7 @@ public:
     void* IsFieldItemBox(unsigned short kindCode);
 
 private:
-    // 65535 pointer slots；對齊反編譯 (char*)this + 0x40008 開始之資料。
+    // 65535 pointer slots (0xFFFF)；對齊反編譯 (char*)this + 0x40008 開始之
+    // 0x3FFFC 位元組資料 (= 65535 * sizeof(cltMonsterAniInfo*))。
     cltMonsterAniInfo** m_ppMonsterAniInfoTable;
 };

--- a/src/Info/cltClientCharKindInfo.cpp
+++ b/src/Info/cltClientCharKindInfo.cpp
@@ -18,9 +18,10 @@ cltClientCharKindInfo::cltClientCharKindInfo()
     //   cltCharKindInfo::cltCharKindInfo(this);             // parent ctor
     //   *(_DWORD *)this = &cltClientCharKindInfo::vftable;  // set derived vtable
     //   memset((char *)this + 262152, 0, 0x3FFFCu);          // zero ani table
-    m_ppMonsterAniInfoTable = new cltMonsterAniInfo*[0x10000];
+    // 0x3FFFC / sizeof(void*) == 0xFFFF slots.
+    m_ppMonsterAniInfoTable = new cltMonsterAniInfo*[0xFFFF];
     std::memset(m_ppMonsterAniInfoTable, 0,
-                sizeof(cltMonsterAniInfo*) * 0x10000);
+                sizeof(cltMonsterAniInfo*) * 0xFFFF);
 }
 
 // (0x00401380) '`scalar deleting destructor'

--- a/src/Logic/CShortKey.cpp
+++ b/src/Logic/CShortKey.cpp
@@ -101,11 +101,9 @@ void CShortKey::SaveKeySetting() {
 // index-tagged sentinel, and falls back to the default table when required
 // bindings (movement keys) have been lost.
 void CShortKey::ProcessInvalidKey() {
-    // Original uses a 1020-byte stack flag table keyed by scan code.  Our
-    // buffer rounds up to 256 ints (1024 bytes) which covers every valid
-    // DirectInput scan code; anything >= 0xFFFFFF is the "unbound" sentinel
-    // and never reaches this path.
-    int seen[256] = { 0 };
+    // 1:1 with mofclient.c: `int v8; char v9[1016];` on the stack forms a
+    // 1020-byte (= 255 int) seen-flag table indexed by the scan code value.
+    int seen[255] = { 0 };
     int anyFixed = 0;
 
     for (unsigned int i = 0; i < KEY_COUNT; ++i) {
@@ -297,11 +295,14 @@ void CShortKey::AdjustClientKey() {
     // GetUserKeySettingName(48, 1) call so the ground-truth call chain runs.
     CUIBase* pW84 = g_UIMgr ? g_UIMgr->GetUIWindow(84) : nullptr;
     if (pW84) {
+        // Ground truth: 64-byte stack buffer cleared then strcpy'd to both the
+        // local copy and the window+140956 slot.
         char buf[64];
-        std::memset(buf, 0, sizeof(buf));
+        buf[0] = '\0';
+        std::memset(buf + 1, 0, sizeof(buf) - 1);
         const char* label = GetUserKeySettingName(48, 1);
-        std::strncpy(buf, label, sizeof(buf) - 1);
-        std::memcpy(reinterpret_cast<char*>(pW84) + 140956, buf, sizeof(buf));
+        std::strcpy(buf, label);
+        std::strcpy(reinterpret_cast<char*>(pW84) + 140956, buf);
     }
 }
 
@@ -370,9 +371,9 @@ void CShortKey::InitStaticDefaultKey() {
     m_nDefaultKey[47] = 20;         // T              (KEYTYPE_ACADEMY)
     m_nDefaultKey[48] = 30;         // A              (KEYTYPE_QUESTALARM)
 
-    // On-screen keyboard layout.  The counter must start at 0 so slots map to
-    // the exact indices the ground truth stores them in.
-    s_nKeyCount = 0;
+    // On-screen keyboard layout.  Ground truth does NOT reset _nKeyCount here —
+    // it relies on the BSS-zero initial value and on InitStaticDefaultKey being
+    // called only once at program startup.  Match that behaviour exactly.
     AddKeyboard(1,   16,  39, "ESC",   0, 0x25u, 0x25u);
     AddKeyboard(59,  94,  39, "F1",    1, 0x25u, 0x25u);
     AddKeyboard(60,  133, 39, "F2",    1, 0x25u, 0x25u);

--- a/src/Logic/cltChattingMgr.cpp
+++ b/src/Logic/cltChattingMgr.cpp
@@ -931,45 +931,39 @@ void cltChattingMgr::DispatchChatOrder_PartyChat(char* text) {
 
 //----- (004F90E0) -----------------------------------------------------------
 void cltChattingMgr::DispatchChatOrder_JoinParty(char* text) {
-    if (!text) return;
-    char temp[1024]{};
-    std::strncpy(temp, text, sizeof(temp) - 1);
-    temp[sizeof(temp) - 1] = '\0';
-    char* tok = std::strtok(temp, " ");
-    if (tok && g_pInterfaceDataCommunity) {
-        char name[128]{};
-        std::strncpy(name, tok, sizeof(name) - 1);
+    // Ground truth: strtok mutates the input directly.  Callers pass a local
+    // stack buffer, so the mutation is self-contained.
+    char delim[2] = " ";
+    char* tok = std::strtok(text, delim);
+    if (tok) {
+        char name[128];
+        std::strcpy(name, tok);
         g_pInterfaceDataCommunity->ChatOrderPartyInvite(name);
     }
 }
 
 //----- (004F9150) -----------------------------------------------------------
 void cltChattingMgr::DispatchChatOrder_KickoutParty(char* text) {
-    if (!text) return;
-    char temp[1024]{};
-    std::strncpy(temp, text, sizeof(temp) - 1);
-    temp[sizeof(temp) - 1] = '\0';
-    char* tok = std::strtok(temp, " ");
-    if (tok && g_pInterfaceDataCommunity) {
-        char name[128]{};
-        std::strncpy(name, tok, sizeof(name) - 1);
+    char delim[2] = " ";
+    char* tok = std::strtok(text, delim);
+    if (tok) {
+        char name[128];
+        std::strcpy(name, tok);
         g_pInterfaceDataCommunity->ChatOrderPartyKickOut(name);
     }
 }
 
 //----- (004F91C0) -----------------------------------------------------------
 void cltChattingMgr::DispatchChatOrder_Whisper(char* text) {
-    if (!text) return;
-    char temp[1024]{};
-    std::strncpy(temp, text, sizeof(temp) - 1);
-    temp[sizeof(temp) - 1] = '\0';
-    char* tok = std::strtok(temp, " ");
-    if (!tok) return;
-    char name[128]{};
-    std::strncpy(name, tok, sizeof(name) - 1);
-    // The remainder of `text` starts right after the space we just replaced.
-    char* body = text + std::strlen(tok) + 1;
-    SendWhisper(name, body);
+    char delim[2] = " ";
+    char* tok = std::strtok(text, delim);
+    if (tok) {
+        char name[128];
+        std::strcpy(name, tok);
+        // Remainder of `text` starts right after the space we just replaced
+        // (ground truth: &text[strlen(tok) + 1]).
+        SendWhisper(name, &text[std::strlen(tok) + 1]);
+    }
 }
 
 //----- (004F9250) -----------------------------------------------------------
@@ -1020,28 +1014,22 @@ void cltChattingMgr::SendWhisper(char* targetName, char* message) {
 
 //----- (004F93A0) -----------------------------------------------------------
 void cltChattingMgr::DispatchChatOrder_JoinCircle(char* text) {
-    if (!text) return;
-    char temp[1024]{};
-    std::strncpy(temp, text, sizeof(temp) - 1);
-    temp[sizeof(temp) - 1] = '\0';
-    char* tok = std::strtok(temp, " ");
-    if (tok && g_pInterfaceDataCommunity) {
-        char name[128]{};
-        std::strncpy(name, tok, sizeof(name) - 1);
+    char delim[2] = " ";
+    char* tok = std::strtok(text, delim);
+    if (tok) {
+        char name[128];
+        std::strcpy(name, tok);
         g_pInterfaceDataCommunity->ChatOrderCircleInvite(name);
     }
 }
 
 //----- (004F9410) -----------------------------------------------------------
 void cltChattingMgr::DispatchChatOrder_KickoutCircle(char* text) {
-    if (!text) return;
-    char temp[1024]{};
-    std::strncpy(temp, text, sizeof(temp) - 1);
-    temp[sizeof(temp) - 1] = '\0';
-    char* tok = std::strtok(temp, " ");
-    if (tok && g_pInterfaceDataCommunity) {
-        char name[128]{};
-        std::strncpy(name, tok, sizeof(name) - 1);
+    char delim[2] = " ";
+    char* tok = std::strtok(text, delim);
+    if (tok) {
+        char name[128];
+        std::strcpy(name, tok);
         g_pInterfaceDataCommunity->ChatOrderCircleKickOut(name);
     }
 }
@@ -1087,27 +1075,24 @@ void cltChattingMgr::DispatchChatOrder_Help(char* /*text*/) {
 
 //----- (004F9760) -----------------------------------------------------------
 void cltChattingMgr::DispatchChatOrder_DetailCharInfo(char* text) {
-    if (!text) return;
-    char temp[1024]{};
-    std::strncpy(temp, text, sizeof(temp) - 1);
-    temp[sizeof(temp) - 1] = '\0';
-    char* tok = std::strtok(temp, " ");
-    if (tok && g_pInterfaceDataCommunity) {
-        char name[128]{};
-        std::strncpy(name, tok, sizeof(name) - 1);
+    char delim[2] = " ";
+    char* tok = std::strtok(text, delim);
+    if (tok) {
+        char name[128];
+        std::strcpy(name, tok);
         g_pInterfaceDataCommunity->OpenUserInfo(name);
     }
 }
 
 //----- (004F97D0) -----------------------------------------------------------
 void cltChattingMgr::FindEmoticonWord(unsigned int accountId, char* message, std::uint16_t emoticonId) {
-    if (!message) return;
+    // Ground truth forwards unconditionally; no null checks.
     m_EmoticonSystem.FindEmoticonWord(accountId, message, emoticonId);
 }
 
 //----- (004F97F0) -----------------------------------------------------------
 void cltChattingMgr::FindEmoticonWord(char* name, char* message, std::uint16_t emoticonId) {
-    if (!name || !message) return;
+    // Ground truth forwards unconditionally; no null checks.
     m_EmoticonSystem.FindEmoticonWord(name, message, emoticonId);
 }
 


### PR DESCRIPTION
## Summary
This PR refactors several chat command parsing functions and related code to align with the original ground truth implementation. The changes focus on simplifying buffer handling, removing unnecessary null checks, and correcting array sizing to match the original binary.

## Key Changes

### Chat Command Parsing (cltChattingMgr.cpp)
- **Simplified strtok usage**: Removed intermediate 1024-byte temporary buffers and now call `strtok()` directly on the input text parameter, matching the ground truth behavior where strtok mutates the input directly
- **Removed redundant null checks**: Eliminated `if (!text)` guards since callers pass stack buffers that are always valid
- **Replaced strncpy with strcpy**: Changed to unsafe `strcpy()` to match original implementation, with the understanding that buffer sizes are guaranteed safe by the calling context
- **Updated Whisper parsing**: Changed pointer arithmetic from `text + std::strlen(tok) + 1` to `&text[std::strlen(tok) + 1]` for clarity
- **Removed g_pInterfaceDataCommunity null checks**: Simplified conditional logic to only check for valid token
- **Emoticon functions**: Removed null parameter checks and added comments noting ground truth forwards unconditionally

### Key Binding System (CShortKey.cpp)
- **Fixed array sizing**: Changed `seen[256]` to `seen[255]` in `ProcessInvalidKey()` to match the exact 1020-byte stack allocation in the original (255 ints = 1020 bytes)
- **Corrected buffer initialization**: Changed from `std::memset(buf, 0, sizeof(buf))` to `buf[0] = '\0'; std::memset(buf + 1, ...)` to match ground truth initialization pattern
- **Replaced strncpy with strcpy**: Updated key setting name copying to use unsafe `strcpy()` matching original behavior
- **Removed memcpy**: Changed to `strcpy()` for copying to window buffer
- **Preserved initialization behavior**: Removed `s_nKeyCount = 0` reset in `InitStaticDefaultKey()` with comment explaining ground truth relies on BSS-zero initialization and single startup call

### Character Animation Info (cltClientCharKindInfo.cpp & .h)
- **Fixed array allocation**: Changed `0x10000` to `0xFFFF` (65535) slots to match the actual 0x3FFFC byte allocation divided by pointer size
- **Updated comments**: Clarified the calculation and alignment with decompiled code showing the correct slot count

## Implementation Details
- All changes are grounded in matching the original binary behavior, with detailed comments explaining the ground truth implementation
- Buffer overflow risks from `strcpy()` are acceptable because the calling context guarantees safe sizes
- The refactoring maintains functional equivalence while improving code clarity and reducing unnecessary defensive programming

https://claude.ai/code/session_01MuGgPE1ux5qguoqWrJY1ho