### PR TITLE
Restore chat blocking and GM bypass logic from decompiled code

### DIFF
--- a/inc/Info/cltClientCharKindInfo.h
+++ b/inc/Info/cltClientCharKindInfo.h
@@ -28,9 +28,10 @@ public:
     // 取得指定 char kind 的等級 (char kind info offset 146, BYTE)
     unsigned char GetCharLevel(unsigned short kindCode);
 
-    // 回傳 (void*) — 對齊反編譯：若 IsFieldItemBox 旗標設定則非 null。
-    // 原始 binary 從 char kind info offset 236 (DWORD) 讀取。
-    void* IsFieldItemBox(unsigned short kindCode);
+    // 回傳 stCharKindInfo*（對齊 mofclient.c 反編譯簽名）。
+    // 原始 binary 從 char kind info offset 236 (DWORD) 讀取一個指標值，
+    // IDA 將其還原為 stCharKindInfo*；呼叫端實際只做 non-null 判定。
+    stCharKindInfo* IsFieldItemBox(unsigned short kindCode);
 
 private:
     // 65535 pointer slots (0xFFFF)；對齊反編譯 (char*)this + 0x40008 開始之

--- a/src/Info/cltClientCharKindInfo.cpp
+++ b/src/Info/cltClientCharKindInfo.cpp
@@ -133,17 +133,19 @@ unsigned char cltClientCharKindInfo::GetCharLevel(unsigned short a2)
 }
 
 // (0x004015B0)
-void* cltClientCharKindInfo::IsFieldItemBox(unsigned short a2)
+stCharKindInfo* cltClientCharKindInfo::IsFieldItemBox(unsigned short a2)
 {
     // mofclient.c:
     //   result = GetCharKindInfo(this, a2);
     //   if ( result )
     //     result = *((_DWORD *)GetCharKindInfo(this, a2) + 59);  // offset 236
     //   return result;
-    void* result = cltCharKindInfo::GetCharKindInfo(a2);
+    stCharKindInfo* result =
+        reinterpret_cast<stCharKindInfo*>(cltCharKindInfo::GetCharKindInfo(a2));
     if (result) {
         void* inner = cltCharKindInfo::GetCharKindInfo(a2);
-        result = *(reinterpret_cast<void**>(reinterpret_cast<char*>(inner) + 236));
+        result = *reinterpret_cast<stCharKindInfo**>(
+            reinterpret_cast<char*>(inner) + 236);
     }
     return result;
 }

--- a/src/Logic/CShortKey.cpp
+++ b/src/Logic/CShortKey.cpp
@@ -23,13 +23,12 @@ strBoardKey CShortKey::m_strBoardKey[CShortKey::BOARD_CAPACITY];
 
 // Text IDs used by DCTTextManager::GetParsedText to print localized labels
 // for each of the 56 short-key slots.  Only the first two entries are visible
-// in the decompiled `m_wUserKeyName = 243928713` (= 0x0E8B0D89), so we recover
-// those and leave the remainder at 0 (GetText will then return the default
-// "no text" string from the DCT table).
+// in the decompiled `m_wUserKeyName = 243928713` (= 0x0E8A0E89, little-endian:
+// low uint16 = 0x0E89 = 3721, high uint16 = 0x0E8A = 3722).  The remaining 54
+// entries live in the data section beyond what the decompilation captured; we
+// leave them at 0 so GetText returns the default "no text" string.
 uint16_t CShortKey::m_wUserKeyName[CShortKey::KEY_COUNT] = {
-    0x0D89, 0x0E8B,   // recovered from mofclient.c int-init; remaining 54
-                      // entries come from the data section and are not
-                      // observable from the decompilation.
+    0x0E89, 0x0E8A,
 };
 
 int CShortKey::s_nKeyCount = 0;

--- a/src/Logic/cltChattingMgr.cpp
+++ b/src/Logic/cltChattingMgr.cpp
@@ -228,13 +228,22 @@ int cltChattingMgr::GetChatWritedString(int direction, char* out) {
 //----- (004F71A0) -----------------------------------------------------------
 void cltChattingMgr::Poll() {
     // Ground truth gate: chat is only active in-game (main-state 10) and when
-    // cltMyCharData is not in a "no-chat" state.  The latter is stored at
-    // offset 76 of cltMyCharData in the decompiled struct; our restored
-    // cltMyCharData does not expose it, so we behave as if it were always 0.
-    if (!m_bChatPostReady || g_dwMainGameState != 10 || !m_pclMyChatData) {
+    // the "no-chat" flag at cltMyCharData + 76 (*(DWORD*)((char*)self + 76),
+    // equivalently *((DWORD*)self + 19)) is zero.  cltMyCharData is opaque in
+    // this restoration, so we read that DWORD via raw offset — matching the
+    // decompiled `!*((_DWORD *)cltChattingMgr::m_pclMyChatData + 19)` gate.
+    auto isChatBlocked = [](const cltMyCharData* data) -> bool {
+        if (!data) return true;
+        return *reinterpret_cast<const std::uint32_t*>(
+                   reinterpret_cast<const char*>(data) + 76) != 0;
+    };
+
+    if (!m_bChatPostReady || g_dwMainGameState != 10 ||
+        !m_pclMyChatData || isChatBlocked(m_pclMyChatData)) {
         // Still drive the live input-line redraw even when submission is not
         // pending, so the cursor keeps blinking.
-        if (g_dwMainGameState == 10 && m_pclMyChatData) {
+        if (g_dwMainGameState == 10 && m_pclMyChatData &&
+            !isChatBlocked(m_pclMyChatData)) {
             SendInputChat();
         }
         return;
@@ -304,9 +313,18 @@ void cltChattingMgr::Poll() {
                         if (m_pNetwork) m_pNetwork->SysCommand(rawText);
                     }
                 } else {
-                    // mofclient.c: when the basic UI is in "remember last
-                    // chat" mode, snapshot the outgoing text.  The UI window
-                    // is not restored yet, so we skip the snapshot.
+                    // mofclient.c: when the basic UI's "remember last chat"
+                    // flag at offset 449284 is 1, snapshot the outgoing text
+                    // into this+79944 (m_szLastChatSent).  CUIBasic is not
+                    // fully restored, so reach the flag via raw offset.
+                    CUIBase* pUIWindow = g_UIMgr ? g_UIMgr->GetUIWindow(0) : nullptr;
+                    if (pUIWindow &&
+                        *reinterpret_cast<const std::uint32_t*>(
+                            reinterpret_cast<const char*>(pUIWindow) + 449284) == 1) {
+                        std::strncpy(m_szLastChatSent, rawText,
+                                     sizeof(m_szLastChatSent) - 1);
+                        m_szLastChatSent[sizeof(m_szLastChatSent) - 1] = '\0';
+                    }
                     SendChattingMsg(rawText);
                 }
             }
@@ -880,10 +898,13 @@ int cltChattingMgr::DispatchChatOrder(char* text) {
     ClientCharacter* me = m_pClientCharMgr ? m_pClientCharMgr->GetMyCharacterPtr() : nullptr;
     if (!me) return 0;
 
-    // The ground truth reads offset +11540 (= *(_DWORD*)me + 2885) for a
-    // "skip validation" flag that GMs set.  Until it's restored we always run
-    // the name-length validation.
-    if (!IsValidCharName(text)) {
+    // Ground truth: skip the IsValidCharName check when the GM / special-auth
+    // flag at ClientCharacter + 11540 (= *((_DWORD*)me + 2885)) is non-zero.
+    // ClientCharacter doesn't expose the field so we read it via raw offset.
+    const std::uint32_t gmBypass =
+        *reinterpret_cast<const std::uint32_t*>(
+            reinterpret_cast<const char*>(me) + 11540);
+    if (!gmBypass && !IsValidCharName(text)) {
         const char* err = g_DCTTextManager.GetText(4745);
         cltSystemMessage::SetSystemMessage(&g_clSysemMessage, err, 0, 0, 0);
         return 1;


### PR DESCRIPTION
## Summary
This PR restores several missing game logic checks from the original decompiled code that were previously stubbed out or incomplete. The changes focus on chat system validation, UI state checks, and character permission flags.

## Key Changes

- **Chat blocking flag check**: Implemented the "no-chat" state validation by reading the flag at `cltMyCharData + 76` via raw offset. This gate now properly blocks chat submission when the flag is set, matching the decompiled ground truth.

- **"Remember last chat" feature**: Restored the snapshot of outgoing chat text into `m_szLastChatSent` when the UI's "remember last chat" flag (at `CUIBase + 449284`) is enabled. Previously this was skipped due to incomplete UI restoration.

- **GM bypass for name validation**: Implemented the GM/special-auth flag check at `ClientCharacter + 11540` to skip character name validation for privileged users, matching the original binary behavior.

- **Type safety improvements**: 
  - Changed `IsFieldItemBox()` return type from `void*` to `stCharKindInfo*` for better type safety and clarity
  - Added proper `reinterpret_cast` usage for raw offset pointer reads
  - Improved comments documenting the offset locations and their purposes

- **Short key name table correction**: Fixed the initialization values in `m_wUserKeyName` from `0x0D89, 0x0E8B` to `0x0E89, 0x0E8A` (correcting the little-endian interpretation of the decompiled constant `0x0E8B0D89`).

## Implementation Details

All raw offset reads are implemented using `reinterpret_cast` with explicit byte offset calculations, with detailed comments explaining the offset locations and their correspondence to the decompiled code. This approach maintains compatibility with opaque/incomplete struct definitions while accurately reflecting the original binary behavior.

https://claude.ai/code/session_011akMZ3Tn9SpBtcq4YJY8QB