### PR TITLE
Implement character name lookup and PK enemy color override

### DIFF
--- a/inc/Character/ClientCharacterManager.h
+++ b/inc/Character/ClientCharacterManager.h
@@ -30,6 +30,10 @@ public:
 	void DeleteAllChar();
 	void SetMyCAClone();
 	char* GetMyCharName();
+	// mofclient.c 0x0040F3E0: returns pointer to the character's m_szName
+	// (offset +460) for the given account id, or an empty string if no
+	// character is currently assigned that account id.
+	char* GetCharName(unsigned int accountId);
 
 	// 繪製相關
 	void PrepareDrawingEtcMark();

--- a/src/Character/ClientCharacterManager.cpp
+++ b/src/Character/ClientCharacterManager.cpp
@@ -139,6 +139,13 @@ char* ClientCharacterManager::GetMyCharName() {
     return pMyChar ? pMyChar->m_szName : nullptr;
 }
 
+// mofclient.c 0x0040F3E0
+char* ClientCharacterManager::GetCharName(unsigned int accountId) {
+    static char s_empty[1] = { '\0' };
+    ClientCharacter* pChar = GetCharByAccount(accountId);
+    return pChar ? pChar->m_szName : s_empty;
+}
+
 ClientCharacter* ClientCharacterManager::GetCharByName(char* name) {
     if (!name) {
         return nullptr;

--- a/src/Logic/cltChattingMgr.cpp
+++ b/src/Logic/cltChattingMgr.cpp
@@ -567,11 +567,10 @@ void cltChattingMgr::SetChatBuffer(std::uint16_t channel, unsigned int accountId
 
     switch (channel) {
         case 1u: {
-            const char* name = m_pClientCharMgr ? nullptr : nullptr;
-            // The real GetCharName takes an account id; restored manager
-            // doesn't expose that yet, so fall back to the empty string.
-            (void)accountId;
-            (void)name;
+            // mofclient.c: strcpy(&v18, ClientCharacterManager::GetCharName(m_pClientCharMgr, a3));
+            const char* name = m_pClientCharMgr ? m_pClientCharMgr->GetCharName(accountId) : "";
+            std::strncpy(nameField, name ? name : "", sizeof(nameField) - 1);
+            nameField[sizeof(nameField) - 1] = '\0';
             filterCode = 1;
             color = static_cast<std::uint32_t>(-1);
             break;
@@ -702,11 +701,17 @@ void cltChattingMgr::SetChatBuffer(std::uint16_t channel, char* name, char* mess
     }
 
     // PK / war opponent bubble — override colour to bright blue.
-    if (m_pClientCharMgr && name) {
+    // mofclient.c:
+    //   v16 = GetCharByName(&g_ClientCharMgr, String2);
+    //   if ( v16 && *((_DWORD *)v16 + 2885) )
+    //       v10 = -16776961;
+    // ClientCharacter does not expose the offset-11540 flag through a named
+    // member, so read it via raw offset like the other call sites do.
+    if (name) {
         ClientCharacter* target = g_ClientCharMgr.GetCharByName(name);
-        if (target) {
-            // mofclient.c checks offset 2885*4 = 11540 (an "is-pk-enemy" flag).
-            // Our ClientCharacter does not expose the field; skip the override.
+        if (target && *reinterpret_cast<const std::uint32_t*>(
+                          reinterpret_cast<const char*>(target) + 11540)) {
+            color = static_cast<std::uint32_t>(-16776961);
         }
     }
 


### PR DESCRIPTION
## Summary
This PR implements proper character name lookup by account ID and restores the PK/war opponent bubble color override feature that was previously stubbed out.

## Key Changes
- **Added `GetCharName(accountId)` method** to `ClientCharacterManager` that retrieves a character's name by account ID, returning an empty string if no character is assigned to that account
- **Implemented character name population** in `SetChatBuffer` for channel 1 chat, using the new `GetCharName` method to properly retrieve and copy the character name into the name field
- **Restored PK enemy color override logic** that checks the "is-pk-enemy" flag at offset 11540 in the `ClientCharacter` structure and applies bright blue color (-16776961) to chat bubbles for PK/war opponents
- **Removed placeholder code** that was previously stubbing out the name lookup and color override functionality

## Implementation Details
- The `GetCharName` method uses a static empty string buffer to safely return a pointer when no character is found, avoiding null pointer issues
- Character name copying uses `std::strncpy` with proper null-termination to prevent buffer overflows
- The PK enemy flag check uses raw pointer arithmetic (`reinterpret_cast`) to access the offset-11540 field since `ClientCharacter` doesn't expose it as a named member, consistent with other call sites in the codebase
- All changes are documented with references to the original mofclient.c implementation

https://claude.ai/code/session_01BC75ywFCjTEnR5iksG8J1N