### PR TITLE
Remove unnecessary bounds checks in climate system code

### DIFF
--- a/src/Logic/CItemClimateUnit.cpp
+++ b/src/Logic/CItemClimateUnit.cpp
@@ -63,10 +63,10 @@ void CItemClimateUnit::Reset() {
     const int sysW = g_Game_System_Info.ScreenWidth;
     const int sysH = g_Game_System_Info.ScreenHeight;
     if (m_iPattern == 1 || m_iPattern == 2) {
-        m_iX = (std::rand() % (sysW > 0 ? sysW : 1)) + dword_A73088;
-        m_iY = dword_A7308C - (std::rand() % (sysH > 0 ? sysH : 1));
+        m_iX = (std::rand() % sysW) + dword_A73088;
+        m_iY = dword_A7308C - (std::rand() % sysH);
         m_iX2 = dword_A73088 + m_iX;
-        m_iLandY = (std::rand() % (sysH > 0 ? sysH : 1)) - 80 + dword_A7308C;
+        m_iLandY = (std::rand() % sysH) - 80 + dword_A7308C;
         m_wField17 = m_wField18;
         m_fFrame = 0.0f;
         m_wCurFrame = 0;
@@ -120,7 +120,7 @@ void CItemClimateUnit::Poll() {
 
     const int sysW = g_Game_System_Info.ScreenWidth;
     if (m_iX - dword_A73088 >= 0) {
-        if (m_iX - dword_A73088 > sysW) {
+        if (sysW < m_iX - dword_A73088) {
             m_iX -= sysW;
         }
     } else {

--- a/src/Logic/CMap_Item_Climate.cpp
+++ b/src/Logic/CMap_Item_Climate.cpp
@@ -21,7 +21,6 @@ void CMap_Item_Climate::Free() {
     m_wUnitCount = 0;
     if (m_dwTimerID) {
         g_clTimerManager.ReleaseTimer(m_dwTimerID);
-        m_dwTimerID = 0;
     }
 }
 
@@ -33,8 +32,7 @@ int CMap_Item_Climate::InitMapItemClimate(unsigned short itemID) {
     m_iActiveStatic = 0;
     m_wUseItemKind  = info->ID;                 // *((_WORD *)v3 + 0) = byte 0
     // *((_WORD *)v3 + 16) = byte 32 = low16(UnitCount)
-    unsigned short n = static_cast<unsigned short>(info->UnitCount);
-    if (n > kMaxUnits) n = kMaxUnits;
+    const unsigned short n = static_cast<unsigned short>(info->UnitCount);
     m_wUnitCount    = n;
     m_dwIconResId   = info->WeatherIconResID;   // *((_DWORD *)v3 + 6) = byte 24
     m_dwIconBlockId = info->BlockID2;           // *((_DWORD *)v3 + 15) = byte 60

--- a/src/Logic/cltMap_Climate.cpp
+++ b/src/Logic/cltMap_Climate.cpp
@@ -49,15 +49,14 @@ void cltClimateUnit::Reset() {
         m_iX = (std::rand() % (sysW + 200)) - 100 + dword_A73088;
         m_iY = (std::rand() % (sysH + 200)) - 100 + dword_A7308C;
     } else {
-        m_iX = (std::rand() % (sysW > 0 ? sysW : 1)) + dword_A73088;
-        m_iY = (std::rand() % (sysH > 0 ? sysH : 1)) + dword_A7308C;
+        m_iX = (std::rand() % sysW) + dword_A73088;
+        m_iY = (std::rand() % sysH) + dword_A7308C;
     }
     m_wCurFrame = m_wStartBlock;
     if (m_dwIsSnowing) {
         m_fFrame = static_cast<float>(m_wStartBlock + (std::rand() & 0xFFFF) % 5);
     } else {
-        const int range = (m_wRandRange > 0) ? m_wRandRange : 1;
-        m_fFrame = static_cast<float>(m_wStartBlock + (std::rand() & 0xFFFF) % range);
+        m_fFrame = static_cast<float>(m_wStartBlock + (std::rand() & 0xFFFF) % m_wRandRange);
     }
 }
 
@@ -90,8 +89,7 @@ void cltClimateUnit::PrepareDrawing() {
              0,  0,  1,  2,  3,  4,  3,  2,  1,  0
         };
         const int idx = static_cast<int>(m_fFrame);
-        const int safeIdx = (idx >= 0 && idx < 18) ? idx : 0;
-        const int sx = m_iX + kOffsets[safeIdx] - dword_A73088;
+        const int sx = m_iX + kOffsets[idx] - dword_A73088;
         const int sy = m_iY - dword_A7308C;
         img->m_wBlockID = m_wCurFrame;
         img->m_bFlag_447 = true;
@@ -140,8 +138,7 @@ void cltMap_Climate::InitClimate(int hasDrawBG, unsigned short climateKind, int 
     auto* info = g_Map.GetClimateKindByClimateKind(climateKind);
     if (!info) return;
     m_iActive    = 1;
-    unsigned short n = info->unitCount;
-    if (n > kMaxUnits) n = kMaxUnits;
+    const unsigned short n = info->unitCount;
     m_wUnitCount = n;
     for (unsigned short i = 0; i < n; ++i) {
         m_units[i].Init(hasDrawBG, climateKind, rangeY);


### PR DESCRIPTION
## Summary
This PR removes unnecessary defensive bounds checks and simplifies conditional logic in the climate system code. The changes assume that screen dimensions and range values are always positive, eliminating redundant ternary operators and bounds validation.

## Key Changes

- **cltMap_Climate.cpp**:
  - Removed ternary operators checking if `sysW` and `sysH` are positive before using them in modulo operations
  - Removed bounds checking for `m_wRandRange` before using it in modulo operation
  - Removed array bounds validation for `kOffsets` array access, trusting that `m_fFrame` will always be in valid range [0, 18)
  - Removed unnecessary clamping of `unitCount` to `kMaxUnits` and made the variable `const`

- **CItemClimateUnit.cpp**:
  - Removed ternary operators checking if `sysW` and `sysH` are positive in three locations
  - Simplified comparison logic by reordering operands (`m_iX - dword_A73088 > sysW` → `sysW < m_iX - dword_A73088`)

- **CMap_Item_Climate.cpp**:
  - Removed unnecessary `m_dwTimerID = 0` assignment after timer release
  - Removed unnecessary clamping of `unitCount` to `kMaxUnits` and made the variable `const`

## Implementation Details
These changes assume that:
- Screen width and height are always positive values
- `m_wRandRange` is always positive
- `m_fFrame` is always within valid bounds for array access
- Unit counts from configuration data don't exceed `kMaxUnits`

The refactoring improves code readability by removing defensive checks that may be unnecessary given the system's initialization and validation logic.

https://claude.ai/code/session_012yDFBEjcriAhHhtXpu6Ji3